### PR TITLE
[iOS] 뱃지 레이블 구현 

### DIFF
--- a/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
+++ b/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		5A88E8F82473C59800DA79F1 /* ReservationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A88E8F72473C59800DA79F1 /* ReservationViewController.swift */; };
 		5A8DB2B424755C30001FC509 /* BadgeLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A8DB2B324755C30001FC509 /* BadgeLabel.swift */; };
+		5A8DB2B624755D3A001FC509 /* BadgeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A8DB2B524755D3A001FC509 /* BadgeViewModel.swift */; };
 		C22A52582473A1A80055A478 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C22A52572473A1A80055A478 /* AppDelegate.swift */; };
 		C22A525A2473A1A80055A478 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C22A52592473A1A80055A478 /* SceneDelegate.swift */; };
 		C22A525C2473A1A80055A478 /* SearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C22A525B2473A1A80055A478 /* SearchViewController.swift */; };
@@ -32,6 +33,7 @@
 /* Begin PBXFileReference section */
 		5A88E8F72473C59800DA79F1 /* ReservationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReservationViewController.swift; sourceTree = "<group>"; };
 		5A8DB2B324755C30001FC509 /* BadgeLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = BadgeLabel.swift; path = Airbnb/Views/BadgeLabel.swift; sourceTree = SOURCE_ROOT; };
+		5A8DB2B524755D3A001FC509 /* BadgeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = BadgeViewModel.swift; path = Airbnb/Controllers/BadgeViewModel.swift; sourceTree = SOURCE_ROOT; };
 		C22A52542473A1A80055A478 /* Airbnb.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Airbnb.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C22A52572473A1A80055A478 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C22A52592473A1A80055A478 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -121,6 +123,7 @@
 		C22A527A2473A2350055A478 /* ViewModels */ = {
 			isa = PBXGroup;
 			children = (
+				5A8DB2B524755D3A001FC509 /* BadgeViewModel.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -259,6 +262,7 @@
 			files = (
 				5A8DB2B424755C30001FC509 /* BadgeLabel.swift in Sources */,
 				5A88E8F82473C59800DA79F1 /* ReservationViewController.swift in Sources */,
+				5A8DB2B624755D3A001FC509 /* BadgeViewModel.swift in Sources */,
 				C22A52802473AAB10055A478 /* BookmarkViewController.swift in Sources */,
 				C22A525C2473A1A80055A478 /* SearchViewController.swift in Sources */,
 				C22A52582473A1A80055A478 /* AppDelegate.swift in Sources */,

--- a/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
+++ b/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		5A88E8F82473C59800DA79F1 /* ReservationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A88E8F72473C59800DA79F1 /* ReservationViewController.swift */; };
+		5A8DB2B424755C30001FC509 /* BadgeLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A8DB2B324755C30001FC509 /* BadgeLabel.swift */; };
 		C22A52582473A1A80055A478 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C22A52572473A1A80055A478 /* AppDelegate.swift */; };
 		C22A525A2473A1A80055A478 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C22A52592473A1A80055A478 /* SceneDelegate.swift */; };
 		C22A525C2473A1A80055A478 /* SearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C22A525B2473A1A80055A478 /* SearchViewController.swift */; };
@@ -30,6 +31,7 @@
 
 /* Begin PBXFileReference section */
 		5A88E8F72473C59800DA79F1 /* ReservationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReservationViewController.swift; sourceTree = "<group>"; };
+		5A8DB2B324755C30001FC509 /* BadgeLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = BadgeLabel.swift; path = Airbnb/Views/BadgeLabel.swift; sourceTree = SOURCE_ROOT; };
 		C22A52542473A1A80055A478 /* Airbnb.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Airbnb.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C22A52572473A1A80055A478 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C22A52592473A1A80055A478 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -111,6 +113,7 @@
 		C22A52792473A21E0055A478 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				5A8DB2B324755C30001FC509 /* BadgeLabel.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -254,6 +257,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5A8DB2B424755C30001FC509 /* BadgeLabel.swift in Sources */,
 				5A88E8F82473C59800DA79F1 /* ReservationViewController.swift in Sources */,
 				C22A52802473AAB10055A478 /* BookmarkViewController.swift in Sources */,
 				C22A525C2473A1A80055A478 /* SearchViewController.swift in Sources */,

--- a/iOS/Airbnb/Airbnb/Base.lproj/Main.storyboard
+++ b/iOS/Airbnb/Airbnb/Base.lproj/Main.storyboard
@@ -15,8 +15,8 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NQg-DY-q2z" customClass="BadgeLabel" customModule="Airbnb" customModuleProvider="target">
-                                <rect key="frame" x="95" y="200" width="42" height="21"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="a" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NQg-DY-q2z" customClass="BadgeLabel" customModule="Airbnb" customModuleProvider="target">
+                                <rect key="frame" x="95" y="200" width="9" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -26,6 +26,7 @@
                         <constraints>
                             <constraint firstItem="NQg-DY-q2z" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="156" id="9f9-jq-1ob"/>
                             <constraint firstItem="NQg-DY-q2z" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="95" id="UVU-iZ-qJZ"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="NQg-DY-q2z" secondAttribute="trailing" symbolic="YES" id="omZ-9k-e1f"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                     </view>

--- a/iOS/Airbnb/Airbnb/Base.lproj/Main.storyboard
+++ b/iOS/Airbnb/Airbnb/Base.lproj/Main.storyboard
@@ -14,19 +14,7 @@
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9XW-4F-I6z" customClass="BadgeLabel" customModule="Airbnb" customModuleProvider="target">
-                                <rect key="frame" x="186" y="418" width="42" height="21"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                        </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
-                        <constraints>
-                            <constraint firstItem="9XW-4F-I6z" firstAttribute="centerY" secondItem="6Tk-OE-BBY" secondAttribute="centerY" id="rKo-xE-Tqh"/>
-                            <constraint firstItem="9XW-4F-I6z" firstAttribute="centerX" secondItem="6Tk-OE-BBY" secondAttribute="centerX" id="zUh-AC-UBh"/>
-                        </constraints>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                     </view>
                     <tabBarItem key="tabBarItem" title="숙소" image="magnifyingglass" catalog="system" id="gmx-4Z-4sl"/>

--- a/iOS/Airbnb/Airbnb/Base.lproj/Main.storyboard
+++ b/iOS/Airbnb/Airbnb/Base.lproj/Main.storyboard
@@ -14,7 +14,19 @@
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NQg-DY-q2z" customClass="BadgeLabel" customModule="Airbnb" customModuleProvider="target">
+                                <rect key="frame" x="95" y="200" width="42" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <constraints>
+                            <constraint firstItem="NQg-DY-q2z" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="156" id="9f9-jq-1ob"/>
+                            <constraint firstItem="NQg-DY-q2z" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="95" id="UVU-iZ-qJZ"/>
+                        </constraints>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                     </view>
                     <tabBarItem key="tabBarItem" title="숙소" image="magnifyingglass" catalog="system" id="gmx-4Z-4sl"/>
@@ -30,6 +42,7 @@
                 <tabBarController automaticallyAdjustsScrollViewInsets="NO" id="WQL-lo-9gs" sceneMemberID="viewController">
                     <toolbarItems/>
                     <tabBar key="tabBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="U2u-F5-9kI">
+                        <rect key="frame" x="0.0" y="0.0" width="1000" height="1000"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     </tabBar>

--- a/iOS/Airbnb/Airbnb/Base.lproj/Main.storyboard
+++ b/iOS/Airbnb/Airbnb/Base.lproj/Main.storyboard
@@ -14,7 +14,19 @@
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9XW-4F-I6z" customClass="BadgeLabel" customModule="Airbnb" customModuleProvider="target">
+                                <rect key="frame" x="186" y="418" width="42" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <constraints>
+                            <constraint firstItem="9XW-4F-I6z" firstAttribute="centerY" secondItem="6Tk-OE-BBY" secondAttribute="centerY" id="rKo-xE-Tqh"/>
+                            <constraint firstItem="9XW-4F-I6z" firstAttribute="centerX" secondItem="6Tk-OE-BBY" secondAttribute="centerX" id="zUh-AC-UBh"/>
+                        </constraints>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                     </view>
                     <tabBarItem key="tabBarItem" title="숙소" image="magnifyingglass" catalog="system" id="gmx-4Z-4sl"/>

--- a/iOS/Airbnb/Airbnb/Base.lproj/Main.storyboard
+++ b/iOS/Airbnb/Airbnb/Base.lproj/Main.storyboard
@@ -14,20 +14,7 @@
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="a" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NQg-DY-q2z" customClass="BadgeLabel" customModule="Airbnb" customModuleProvider="target">
-                                <rect key="frame" x="95" y="200" width="9" height="21"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                        </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
-                        <constraints>
-                            <constraint firstItem="NQg-DY-q2z" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="156" id="9f9-jq-1ob"/>
-                            <constraint firstItem="NQg-DY-q2z" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="95" id="UVU-iZ-qJZ"/>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="NQg-DY-q2z" secondAttribute="trailing" symbolic="YES" id="omZ-9k-e1f"/>
-                        </constraints>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                     </view>
                     <tabBarItem key="tabBarItem" title="숙소" image="magnifyingglass" catalog="system" id="gmx-4Z-4sl"/>

--- a/iOS/Airbnb/Airbnb/Controllers/BadgeViewModel.swift
+++ b/iOS/Airbnb/Airbnb/Controllers/BadgeViewModel.swift
@@ -1,0 +1,13 @@
+//
+//  BadgeViewModel.swift
+//  Airbnb
+//
+//  Created by kimdo2297 on 2020/05/20.
+//  Copyright © 2020 Chaewan Park. All rights reserved.
+//
+
+import Foundation
+
+final class BadgeViewModel {
+    static let text = "SUPERHOST"
+}

--- a/iOS/Airbnb/Airbnb/Controllers/BadgeViewModel.swift
+++ b/iOS/Airbnb/Airbnb/Controllers/BadgeViewModel.swift
@@ -16,4 +16,8 @@ final class BadgeViewModel {
     enum Font {
         static let `default` = UIFont.systemFont(ofSize: 12, weight: .semibold)
     }
+    
+    enum Color {
+        static let defaultText = UIColor.black
+    }
 }

--- a/iOS/Airbnb/Airbnb/Controllers/BadgeViewModel.swift
+++ b/iOS/Airbnb/Airbnb/Controllers/BadgeViewModel.swift
@@ -9,5 +9,7 @@
 import Foundation
 
 final class BadgeViewModel {
-    static let text = "SUPERHOST"
+    enum Text {
+        static let `default` = "SUPERHOST"
+    }
 }

--- a/iOS/Airbnb/Airbnb/Controllers/BadgeViewModel.swift
+++ b/iOS/Airbnb/Airbnb/Controllers/BadgeViewModel.swift
@@ -6,10 +6,14 @@
 //  Copyright © 2020 Chaewan Park. All rights reserved.
 //
 
-import Foundation
+import UIKit
 
 final class BadgeViewModel {
     enum Text {
         static let `default` = "SUPERHOST"
+    }
+    
+    enum Font {
+        static let `default` = UIFont.systemFont(ofSize: 12, weight: .semibold)
     }
 }

--- a/iOS/Airbnb/Airbnb/Views/BadgeLabel.swift
+++ b/iOS/Airbnb/Airbnb/Views/BadgeLabel.swift
@@ -25,7 +25,7 @@ final class BadgeLabel: UILabel {
     }
     
     private func configureText() {
-        text = BadgeViewModel.text
+        text = BadgeViewModel.Text.default
     }
     
     private func configureFont() {

--- a/iOS/Airbnb/Airbnb/Views/BadgeLabel.swift
+++ b/iOS/Airbnb/Airbnb/Views/BadgeLabel.swift
@@ -14,12 +14,14 @@ final class BadgeLabel: UILabel {
         translatesAutoresizingMaskIntoConstraints = false
         configureText()
         configureFont()
+        configureBorder()
     }
     
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         configureText()
         configureFont()
+        configureBorder()
     }
     
     private func configureText() {
@@ -28,5 +30,10 @@ final class BadgeLabel: UILabel {
     
     private func configureFont() {
         font = UIFont.systemFont(ofSize: 12, weight: .semibold)
+    }
+    
+    private func configureBorder() {
+        layer.borderWidth = 1
+        layer.cornerRadius = 4
     }
 }

--- a/iOS/Airbnb/Airbnb/Views/BadgeLabel.swift
+++ b/iOS/Airbnb/Airbnb/Views/BadgeLabel.swift
@@ -36,4 +36,28 @@ final class BadgeLabel: UILabel {
         layer.borderWidth = 1
         layer.cornerRadius = 4
     }
+    
+    private enum Padding {
+        static let left: CGFloat = 6
+        static let right: CGFloat = 6
+        static let top: CGFloat = 2
+        static let bottom: CGFloat = 2
+    }
+    
+    override var intrinsicContentSize: CGSize {
+        let `super` = super.intrinsicContentSize
+        return CGSize(
+            width: `super`.width + Padding.left + Padding.right,
+            height: `super`.height + Padding.top + Padding.bottom
+        )
+    }
+    
+    override func drawText(in rect: CGRect) {
+        let inset = UIEdgeInsets(
+            top: Padding.top,
+            left: Padding.left,
+            bottom: Padding.bottom,
+            right: Padding.right)
+        super.drawText(in: rect.inset(by: inset))
+    }
 }

--- a/iOS/Airbnb/Airbnb/Views/BadgeLabel.swift
+++ b/iOS/Airbnb/Airbnb/Views/BadgeLabel.swift
@@ -1,0 +1,19 @@
+//
+//  BadgeLabel.swift
+//  Airbnb
+//
+//  Created by kimdo2297 on 2020/05/20.
+//  Copyright © 2020 Chaewan Park. All rights reserved.
+//
+
+import UIKit
+
+final class BadgeLabel: UILabel {
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+}

--- a/iOS/Airbnb/Airbnb/Views/BadgeLabel.swift
+++ b/iOS/Airbnb/Airbnb/Views/BadgeLabel.swift
@@ -11,7 +11,6 @@ import UIKit
 final class BadgeLabel: UILabel {
     override init(frame: CGRect) {
         super.init(frame: frame)
-        translatesAutoresizingMaskIntoConstraints = false
         configureText()
         configureFont()
         configureBorder()

--- a/iOS/Airbnb/Airbnb/Views/BadgeLabel.swift
+++ b/iOS/Airbnb/Airbnb/Views/BadgeLabel.swift
@@ -11,9 +11,15 @@ import UIKit
 final class BadgeLabel: UILabel {
     override init(frame: CGRect) {
         super.init(frame: frame)
+        configureText()
     }
     
     required init?(coder: NSCoder) {
         super.init(coder: coder)
+        configureText()
+    }
+    
+    private func configureText() {
+        text = BadgeViewModel.text
     }
 }

--- a/iOS/Airbnb/Airbnb/Views/BadgeLabel.swift
+++ b/iOS/Airbnb/Airbnb/Views/BadgeLabel.swift
@@ -29,7 +29,7 @@ final class BadgeLabel: UILabel {
     }
     
     private func configureFont() {
-        font = UIFont.systemFont(ofSize: 12, weight: .semibold)
+        font = BadgeViewModel.Font.default
     }
     
     private func configureBorder() {

--- a/iOS/Airbnb/Airbnb/Views/BadgeLabel.swift
+++ b/iOS/Airbnb/Airbnb/Views/BadgeLabel.swift
@@ -26,6 +26,7 @@ final class BadgeLabel: UILabel {
     
     private func configureText() {
         text = BadgeViewModel.Text.default
+        textColor = BadgeViewModel.Color.defaultText
     }
     
     private func configureFont() {

--- a/iOS/Airbnb/Airbnb/Views/BadgeLabel.swift
+++ b/iOS/Airbnb/Airbnb/Views/BadgeLabel.swift
@@ -11,15 +11,22 @@ import UIKit
 final class BadgeLabel: UILabel {
     override init(frame: CGRect) {
         super.init(frame: frame)
+        translatesAutoresizingMaskIntoConstraints = false
         configureText()
+        configureFont()
     }
     
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         configureText()
+        configureFont()
     }
     
     private func configureText() {
         text = BadgeViewModel.text
+    }
+    
+    private func configureFont() {
+        font = UIFont.systemFont(ofSize: 12, weight: .semibold)
     }
 }


### PR DESCRIPTION
### 뱃지 레이블 구현을 구현하였습니다.
> Issue #6 의 내용을 구현하였습니다.

* 뱃지 레이블에 대한 font와 border에 대한 설정 메소드는 뱃지 레이블 클래스에서 구현하였습니다.
* 뱃지 레이블에 대한 text 값은 로컬라이즈를 고려하여 `BadgeViewModel`이 상수로 갖게 하고 뱃지 레이블 생성시 해당 상수값을 적용하였습니다.
* 패딩 값을 주기 위해 enum `Padding`을 선언하고 `drawText`, `intrinsicContentSize`를 오버라이딩 하였습니다.

> 말씀드릴 점 

* 지도 화면에도 뱃지(superhost) 레이블이 있어서 뱃지에 대한 뷰모델이 독자적으로 있어도 된다고 판단했습니다. 그래서 우선 `BadgeViewModel`을 만들어서 상수를 선언했는데 어떠신가요?  

* 패딩 값에 필요한 enum `Padding`, `drawText`, `intrinsicContentSize` 가 한눈에 보이도록 연달아 위치하도록 하였습니다. 음, 요것들 위치가 맘에 안드시면 알려주세요~!

> 구현 이미지

<img width="78" alt="badgeLabel" src="https://user-images.githubusercontent.com/38216027/82451432-f3b46f00-9ae8-11ea-825c-9fb3665eaa29.png">

=> 해당 이미지를 위해 스토리보드에서 임시로 추가했었지만 바로 삭제하였습니다. 
