### PR TITLE
[iOS] 커스텀 가이드(Guide) 레이블 구현 

### DIFF
--- a/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
+++ b/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		5A840974247649DD00D84413 /* GuideLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A840973247649DD00D84413 /* GuideLabel.swift */; };
 		5A88E8F82473C59800DA79F1 /* ReservationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A88E8F72473C59800DA79F1 /* ReservationViewController.swift */; };
 		5A8DB2B424755C30001FC509 /* BadgeLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A8DB2B324755C30001FC509 /* BadgeLabel.swift */; };
 		5A8DB2B624755D3A001FC509 /* BadgeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A8DB2B524755D3A001FC509 /* BadgeViewModel.swift */; };
@@ -31,6 +32,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		5A840973247649DD00D84413 /* GuideLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuideLabel.swift; sourceTree = "<group>"; };
 		5A88E8F72473C59800DA79F1 /* ReservationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReservationViewController.swift; sourceTree = "<group>"; };
 		5A8DB2B324755C30001FC509 /* BadgeLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = BadgeLabel.swift; path = Airbnb/Views/BadgeLabel.swift; sourceTree = SOURCE_ROOT; };
 		5A8DB2B524755D3A001FC509 /* BadgeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = BadgeViewModel.swift; path = Airbnb/Controllers/BadgeViewModel.swift; sourceTree = SOURCE_ROOT; };
@@ -116,6 +118,7 @@
 			isa = PBXGroup;
 			children = (
 				5A8DB2B324755C30001FC509 /* BadgeLabel.swift */,
+				5A840973247649DD00D84413 /* GuideLabel.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -261,6 +264,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5A8DB2B424755C30001FC509 /* BadgeLabel.swift in Sources */,
+				5A840974247649DD00D84413 /* GuideLabel.swift in Sources */,
 				5A88E8F82473C59800DA79F1 /* ReservationViewController.swift in Sources */,
 				5A8DB2B624755D3A001FC509 /* BadgeViewModel.swift in Sources */,
 				C22A52802473AAB10055A478 /* BookmarkViewController.swift in Sources */,

--- a/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
+++ b/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		5A840974247649DD00D84413 /* GuideLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A840973247649DD00D84413 /* GuideLabel.swift */; };
+		5A84097624764AD700D84413 /* GuideLabelViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A84097524764AD700D84413 /* GuideLabelViewModel.swift */; };
 		5A88E8F82473C59800DA79F1 /* ReservationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A88E8F72473C59800DA79F1 /* ReservationViewController.swift */; };
 		5A8DB2B424755C30001FC509 /* BadgeLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A8DB2B324755C30001FC509 /* BadgeLabel.swift */; };
 		5A8DB2B624755D3A001FC509 /* BadgeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A8DB2B524755D3A001FC509 /* BadgeViewModel.swift */; };
@@ -33,6 +34,7 @@
 
 /* Begin PBXFileReference section */
 		5A840973247649DD00D84413 /* GuideLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuideLabel.swift; sourceTree = "<group>"; };
+		5A84097524764AD700D84413 /* GuideLabelViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = GuideLabelViewModel.swift; path = Airbnb/Views/GuideLabelViewModel.swift; sourceTree = SOURCE_ROOT; };
 		5A88E8F72473C59800DA79F1 /* ReservationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReservationViewController.swift; sourceTree = "<group>"; };
 		5A8DB2B324755C30001FC509 /* BadgeLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = BadgeLabel.swift; path = Airbnb/Views/BadgeLabel.swift; sourceTree = SOURCE_ROOT; };
 		5A8DB2B524755D3A001FC509 /* BadgeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = BadgeViewModel.swift; path = Airbnb/Controllers/BadgeViewModel.swift; sourceTree = SOURCE_ROOT; };
@@ -127,6 +129,7 @@
 			isa = PBXGroup;
 			children = (
 				5A8DB2B524755D3A001FC509 /* BadgeViewModel.swift */,
+				5A84097524764AD700D84413 /* GuideLabelViewModel.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -263,6 +266,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5A84097624764AD700D84413 /* GuideLabelViewModel.swift in Sources */,
 				5A8DB2B424755C30001FC509 /* BadgeLabel.swift in Sources */,
 				5A840974247649DD00D84413 /* GuideLabel.swift in Sources */,
 				5A88E8F82473C59800DA79F1 /* ReservationViewController.swift in Sources */,

--- a/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
+++ b/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		5A840974247649DD00D84413 /* GuideLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A840973247649DD00D84413 /* GuideLabel.swift */; };
 		5A84097624764AD700D84413 /* GuideLabelViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A84097524764AD700D84413 /* GuideLabelViewModel.swift */; };
+		5A840979247651A200D84413 /* UIColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A840978247651A200D84413 /* UIColorExtension.swift */; };
 		5A88E8F82473C59800DA79F1 /* ReservationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A88E8F72473C59800DA79F1 /* ReservationViewController.swift */; };
 		5A8DB2B424755C30001FC509 /* BadgeLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A8DB2B324755C30001FC509 /* BadgeLabel.swift */; };
 		5A8DB2B624755D3A001FC509 /* BadgeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A8DB2B524755D3A001FC509 /* BadgeViewModel.swift */; };
@@ -35,6 +36,7 @@
 /* Begin PBXFileReference section */
 		5A840973247649DD00D84413 /* GuideLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuideLabel.swift; sourceTree = "<group>"; };
 		5A84097524764AD700D84413 /* GuideLabelViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = GuideLabelViewModel.swift; path = Airbnb/Views/GuideLabelViewModel.swift; sourceTree = SOURCE_ROOT; };
+		5A840978247651A200D84413 /* UIColorExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIColorExtension.swift; sourceTree = "<group>"; };
 		5A88E8F72473C59800DA79F1 /* ReservationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReservationViewController.swift; sourceTree = "<group>"; };
 		5A8DB2B324755C30001FC509 /* BadgeLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = BadgeLabel.swift; path = Airbnb/Views/BadgeLabel.swift; sourceTree = SOURCE_ROOT; };
 		5A8DB2B524755D3A001FC509 /* BadgeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = BadgeViewModel.swift; path = Airbnb/Controllers/BadgeViewModel.swift; sourceTree = SOURCE_ROOT; };
@@ -70,6 +72,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		5A8409772476518800D84413 /* Utils */ = {
+			isa = PBXGroup;
+			children = (
+				5A840978247651A200D84413 /* UIColorExtension.swift */,
+			);
+			path = Utils;
+			sourceTree = "<group>";
+		};
 		C22A524B2473A1A70055A478 = {
 			isa = PBXGroup;
 			children = (
@@ -91,6 +101,7 @@
 		C22A52562473A1A80055A478 /* Airbnb */ = {
 			isa = PBXGroup;
 			children = (
+				5A8409772476518800D84413 /* Utils */,
 				C22A52792473A21E0055A478 /* Views */,
 				C22A527A2473A2350055A478 /* ViewModels */,
 				C22A527D2473A2620055A478 /* Controllers */,
@@ -273,6 +284,7 @@
 				5A8DB2B624755D3A001FC509 /* BadgeViewModel.swift in Sources */,
 				C22A52802473AAB10055A478 /* BookmarkViewController.swift in Sources */,
 				C22A525C2473A1A80055A478 /* SearchViewController.swift in Sources */,
+				5A840979247651A200D84413 /* UIColorExtension.swift in Sources */,
 				C22A52582473A1A80055A478 /* AppDelegate.swift in Sources */,
 				C22A525A2473A1A80055A478 /* SceneDelegate.swift in Sources */,
 			);

--- a/iOS/Airbnb/Airbnb/Assets.xcassets/dimGray.colorset/Contents.json
+++ b/iOS/Airbnb/Airbnb/Assets.xcassets/dimGray.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.439",
+          "green" : "0.439",
+          "red" : "0.439"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/iOS/Airbnb/Airbnb/Base.lproj/Main.storyboard
+++ b/iOS/Airbnb/Airbnb/Base.lproj/Main.storyboard
@@ -14,19 +14,7 @@
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6cA-im-UNg" customClass="GuideLabel" customModule="Airbnb" customModuleProvider="target">
-                                <rect key="frame" x="186" y="418.5" width="42" height="20.5"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                        </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
-                        <constraints>
-                            <constraint firstItem="6cA-im-UNg" firstAttribute="centerX" secondItem="6Tk-OE-BBY" secondAttribute="centerX" id="E1h-Ye-Pz9"/>
-                            <constraint firstItem="6cA-im-UNg" firstAttribute="centerY" secondItem="6Tk-OE-BBY" secondAttribute="centerY" id="H0u-Y1-jpl"/>
-                        </constraints>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                     </view>
                     <tabBarItem key="tabBarItem" title="숙소" image="magnifyingglass" catalog="system" id="gmx-4Z-4sl"/>

--- a/iOS/Airbnb/Airbnb/Base.lproj/Main.storyboard
+++ b/iOS/Airbnb/Airbnb/Base.lproj/Main.storyboard
@@ -14,7 +14,19 @@
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6cA-im-UNg" customClass="GuideLabel" customModule="Airbnb" customModuleProvider="target">
+                                <rect key="frame" x="186" y="418.5" width="42" height="20.5"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <constraints>
+                            <constraint firstItem="6cA-im-UNg" firstAttribute="centerX" secondItem="6Tk-OE-BBY" secondAttribute="centerX" id="E1h-Ye-Pz9"/>
+                            <constraint firstItem="6cA-im-UNg" firstAttribute="centerY" secondItem="6Tk-OE-BBY" secondAttribute="centerY" id="H0u-Y1-jpl"/>
+                        </constraints>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                     </view>
                     <tabBarItem key="tabBarItem" title="숙소" image="magnifyingglass" catalog="system" id="gmx-4Z-4sl"/>
@@ -22,7 +34,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="623" y="139"/>
+            <point key="canvasLocation" x="621.73913043478262" y="138.61607142857142"/>
         </scene>
         <!--Tab Bar Controller-->
         <scene sceneID="nxY-Pa-Tcl">

--- a/iOS/Airbnb/Airbnb/Utils/UIColorExtension.swift
+++ b/iOS/Airbnb/Airbnb/Utils/UIColorExtension.swift
@@ -1,0 +1,13 @@
+//
+//  UIColorExtension.swift
+//  Airbnb
+//
+//  Created by kimdo2297 on 2020/05/21.
+//  Copyright © 2020 Chaewan Park. All rights reserved.
+//
+
+import UIKit
+
+extension UIColor {
+    static let dimGray = UIColor.init(named: "dimGray")
+}

--- a/iOS/Airbnb/Airbnb/Views/GuideLabel.swift
+++ b/iOS/Airbnb/Airbnb/Views/GuideLabel.swift
@@ -21,5 +21,6 @@ final class GuideLabel: UILabel {
     
     private func configureText() {
         text = GuideLabelViewModel.Text.default
+        textColor = GuideLabelViewModel.Color.defaultText
     }
 }

--- a/iOS/Airbnb/Airbnb/Views/GuideLabel.swift
+++ b/iOS/Airbnb/Airbnb/Views/GuideLabel.swift
@@ -11,9 +11,15 @@ import UIKit
 final class GuideLabel: UILabel {
     override init(frame: CGRect) {
         super.init(frame: frame)
+        configureText()
     }
     
     required init?(coder: NSCoder) {
         super.init(coder: coder)
+        configureText()
+    }
+    
+    private func configureText() {
+        text = GuideLabelViewModel.Text.default
     }
 }

--- a/iOS/Airbnb/Airbnb/Views/GuideLabel.swift
+++ b/iOS/Airbnb/Airbnb/Views/GuideLabel.swift
@@ -1,0 +1,19 @@
+//
+//  GuideLabel.swift
+//  Airbnb
+//
+//  Created by kimdo2297 on 2020/05/21.
+//  Copyright © 2020 Chaewan Park. All rights reserved.
+//
+
+import UIKit
+
+final class GuideLabel: UILabel {
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+}

--- a/iOS/Airbnb/Airbnb/Views/GuideLabel.swift
+++ b/iOS/Airbnb/Airbnb/Views/GuideLabel.swift
@@ -12,15 +12,21 @@ final class GuideLabel: UILabel {
     override init(frame: CGRect) {
         super.init(frame: frame)
         configureText()
+        configureFont()
     }
     
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         configureText()
+        configureFont()
     }
     
     private func configureText() {
         text = GuideLabelViewModel.Text.default
         textColor = GuideLabelViewModel.Color.defaultText
+    }
+    
+    private func configureFont() {
+        font = GuideLabelViewModel.Font.default
     }
 }

--- a/iOS/Airbnb/Airbnb/Views/GuideLabelViewModel.swift
+++ b/iOS/Airbnb/Airbnb/Views/GuideLabelViewModel.swift
@@ -6,10 +6,14 @@
 //  Copyright © 2020 Chaewan Park. All rights reserved.
 //
 
-import Foundation
+import UIKit
 
 final class GuideLabelViewModel {
     enum Text {
         static let `default` = "날짜와 인원을 선택하시면 가격별 숙소를 추천해드립니다."
+    }
+    
+    enum Color {
+        static let defaultText = UIColor.darkGray
     }
 }

--- a/iOS/Airbnb/Airbnb/Views/GuideLabelViewModel.swift
+++ b/iOS/Airbnb/Airbnb/Views/GuideLabelViewModel.swift
@@ -18,6 +18,6 @@ final class GuideLabelViewModel {
     }
     
     enum Color {
-        static let defaultText = UIColor.darkGray
+        static let defaultText = UIColor.dimGray
     }
 }

--- a/iOS/Airbnb/Airbnb/Views/GuideLabelViewModel.swift
+++ b/iOS/Airbnb/Airbnb/Views/GuideLabelViewModel.swift
@@ -14,7 +14,7 @@ final class GuideLabelViewModel {
     }
     
     enum Font {
-        static let `default` = UIFont.systemFont(ofSize: 16, weight: .regular)
+        static let `default` = UIFont.systemFont(ofSize: 15.5, weight: .medium)
     }
     
     enum Color {

--- a/iOS/Airbnb/Airbnb/Views/GuideLabelViewModel.swift
+++ b/iOS/Airbnb/Airbnb/Views/GuideLabelViewModel.swift
@@ -13,6 +13,10 @@ final class GuideLabelViewModel {
         static let `default` = "날짜와 인원을 선택하시면 가격별 숙소를 추천해드립니다."
     }
     
+    enum Font {
+        static let `default` = UIFont.systemFont(ofSize: 16, weight: .regular)
+    }
+    
     enum Color {
         static let defaultText = UIColor.darkGray
     }

--- a/iOS/Airbnb/Airbnb/Views/GuideLabelViewModel.swift
+++ b/iOS/Airbnb/Airbnb/Views/GuideLabelViewModel.swift
@@ -1,0 +1,15 @@
+//
+//  GuideLabelViewModel.swift
+//  Airbnb
+//
+//  Created by kimdo2297 on 2020/05/21.
+//  Copyright © 2020 Chaewan Park. All rights reserved.
+//
+
+import Foundation
+
+final class GuideLabelViewModel {
+    enum Text {
+        static let `default` = "날짜와 인원을 선택하시면 가격별 숙소를 추천해드립니다."
+    }
+}


### PR DESCRIPTION
### 커스텀 가이드 레이블을 구현하였습니다. 
> Issue #8 을 구현하였습니다. 

* 클래스명을 유저에게 가이드하는 레이블이라 `GuideLabel`이라고 이름 지었습니다. 
* 해당 뷰에 대해 뷰모델 객체 `GuideLabelViewModel`를 구현하였습니다. 
  * 뷰의 기본(default) 텍스트 값을 뷰모델에 선언하였습니다.
  * 뷰의 기본 컬러 값을 뷰모델에 선언하였습니다.
    * 컬러 값은 Assets에 색을 추가하고 extension 을 이용해 UIColor에 상수값을 추가하여 사용하였습니다.
  * 뷰의 기본 폰트 값을 뷰모델에 선언하였습니다. 

> 구현 이미지 

<img width="400" alt="GuideLabel" src="https://user-images.githubusercontent.com/38216027/82529933-0ecdc000-9b77-11ea-984d-0745630ef71f.png">

* 해당 이미지를 캡처하기 위해 스토리보드에 뷰를 추가하고 바로 삭제하였습니다.
