### PR TITLE
[iOS] 스토리보드 구성 및 레이아웃

### DIFF
--- a/iOS/Airbnb/Airbnb/Assets.xcassets/searchBarBorderGray.colorset/Contents.json
+++ b/iOS/Airbnb/Airbnb/Assets.xcassets/searchBarBorderGray.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xE0",
+          "green" : "0xE0",
+          "red" : "0xE0"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/iOS/Airbnb/Airbnb/Assets.xcassets/textGray.colorset/Contents.json
+++ b/iOS/Airbnb/Airbnb/Assets.xcassets/textGray.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.439",
-          "green" : "0.439",
-          "red" : "0.439"
+          "blue" : "0x70",
+          "green" : "0x70",
+          "red" : "0x70"
         }
       },
       "idiom" : "universal"

--- a/iOS/Airbnb/Airbnb/Base.lproj/Main.storyboard
+++ b/iOS/Airbnb/Airbnb/Base.lproj/Main.storyboard
@@ -33,7 +33,7 @@
                                 </userDefinedRuntimeAttributes>
                             </textField>
                             <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="fB2-6l-Zaj">
-                                <rect key="frame" x="24" y="113" width="214" height="38"/>
+                                <rect key="frame" x="24" y="110" width="214" height="38"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="giF-a2-P29" customClass="DateButton" customModule="Airbnb" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="0.0" width="66" height="38"/>
@@ -100,10 +100,19 @@
                                     </button>
                                 </subviews>
                             </stackView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="날짜와 인원을 선택하시면 가격별 숙소를 추천해드립니다." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3YV-Ra-IIz">
+                                <rect key="frame" x="24" y="162" width="327" height="15.666666666666657"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                                <color key="textColor" name="textGray"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <constraints>
-                            <constraint firstItem="fB2-6l-Zaj" firstAttribute="top" secondItem="7ak-5z-ugy" secondAttribute="bottom" constant="17" id="Bx4-Mc-xUJ"/>
+                            <constraint firstItem="fB2-6l-Zaj" firstAttribute="top" secondItem="7ak-5z-ugy" secondAttribute="bottom" constant="14" id="Bx4-Mc-xUJ"/>
+                            <constraint firstItem="7ak-5z-ugy" firstAttribute="leading" secondItem="3YV-Ra-IIz" secondAttribute="leading" id="P08-MX-11S"/>
+                            <constraint firstItem="3YV-Ra-IIz" firstAttribute="top" secondItem="fB2-6l-Zaj" secondAttribute="bottom" constant="14" id="SPo-Xm-9gS"/>
+                            <constraint firstItem="3YV-Ra-IIz" firstAttribute="trailing" secondItem="7ak-5z-ugy" secondAttribute="trailing" id="kqO-I1-pXY"/>
                             <constraint firstItem="7ak-5z-ugy" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="8" id="lcq-MH-T72"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="7ak-5z-ugy" secondAttribute="trailing" constant="24" id="qt7-zg-dbA"/>
                             <constraint firstItem="fB2-6l-Zaj" firstAttribute="leading" secondItem="7ak-5z-ugy" secondAttribute="leading" id="uWF-vS-7bX"/>

--- a/iOS/Airbnb/Airbnb/Base.lproj/Main.storyboard
+++ b/iOS/Airbnb/Airbnb/Base.lproj/Main.storyboard
@@ -117,7 +117,7 @@
                                     <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                 </collectionViewFlowLayout>
                                 <cells>
-                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="e2H-bD-pcl">
+                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="BNBCell" id="e2H-bD-pcl">
                                         <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="9mz-Qc-uJZ">

--- a/iOS/Airbnb/Airbnb/Base.lproj/Main.storyboard
+++ b/iOS/Airbnb/Airbnb/Base.lproj/Main.storyboard
@@ -5,6 +5,7 @@
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="collection view cell content view" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -106,12 +107,36 @@
                                 <color key="textColor" name="textGray"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="cNL-Dt-uNR">
+                                <rect key="frame" x="24" y="205.66666666666669" width="327" height="523.33333333333326"/>
+                                <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="frZ-Yj-eii">
+                                    <size key="itemSize" width="128" height="128"/>
+                                    <size key="headerReferenceSize" width="0.0" height="0.0"/>
+                                    <size key="footerReferenceSize" width="0.0" height="0.0"/>
+                                    <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                </collectionViewFlowLayout>
+                                <cells>
+                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="e2H-bD-pcl">
+                                        <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="9mz-Qc-uJZ">
+                                            <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </collectionViewCellContentView>
+                                    </collectionViewCell>
+                                </cells>
+                            </collectionView>
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <constraints>
                             <constraint firstItem="fB2-6l-Zaj" firstAttribute="top" secondItem="7ak-5z-ugy" secondAttribute="bottom" constant="14" id="Bx4-Mc-xUJ"/>
+                            <constraint firstItem="cNL-Dt-uNR" firstAttribute="trailing" secondItem="7ak-5z-ugy" secondAttribute="trailing" id="FKZ-wm-eNn"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="cNL-Dt-uNR" secondAttribute="bottom" id="OcK-8o-Atg"/>
                             <constraint firstItem="7ak-5z-ugy" firstAttribute="leading" secondItem="3YV-Ra-IIz" secondAttribute="leading" id="P08-MX-11S"/>
                             <constraint firstItem="3YV-Ra-IIz" firstAttribute="top" secondItem="fB2-6l-Zaj" secondAttribute="bottom" constant="14" id="SPo-Xm-9gS"/>
+                            <constraint firstItem="cNL-Dt-uNR" firstAttribute="top" secondItem="3YV-Ra-IIz" secondAttribute="bottom" constant="28" id="dYE-rX-GiS"/>
+                            <constraint firstItem="cNL-Dt-uNR" firstAttribute="leading" secondItem="7ak-5z-ugy" secondAttribute="leading" id="jwK-u7-k1i"/>
                             <constraint firstItem="3YV-Ra-IIz" firstAttribute="trailing" secondItem="7ak-5z-ugy" secondAttribute="trailing" id="kqO-I1-pXY"/>
                             <constraint firstItem="7ak-5z-ugy" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="8" id="lcq-MH-T72"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="7ak-5z-ugy" secondAttribute="trailing" constant="24" id="qt7-zg-dbA"/>

--- a/iOS/Airbnb/Airbnb/Base.lproj/Main.storyboard
+++ b/iOS/Airbnb/Airbnb/Base.lproj/Main.storyboard
@@ -3,6 +3,7 @@
     <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -14,7 +15,30 @@
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="7ak-5z-ugy" customClass="SearchTextField" customModule="Airbnb" customModuleProvider="target">
+                                <rect key="frame" x="24" y="52" width="327" height="44"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="44" id="gsC-eE-4JE"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits"/>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="color" keyPath="color">
+                                        <color key="value" name="searchBarBorderGray"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
+                                        <real key="value" value="1"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                            </textField>
+                        </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <constraints>
+                            <constraint firstItem="7ak-5z-ugy" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="8" id="lcq-MH-T72"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="7ak-5z-ugy" secondAttribute="trailing" constant="24" id="qt7-zg-dbA"/>
+                            <constraint firstItem="7ak-5z-ugy" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="24" id="xpd-xn-bP2"/>
+                        </constraints>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                     </view>
                     <tabBarItem key="tabBarItem" title="숙소" image="magnifyingglass" catalog="system" id="gmx-4Z-4sl"/>
@@ -81,5 +105,8 @@
         <image name="heart.fill" catalog="system" width="128" height="109"/>
         <image name="magnifyingglass" catalog="system" width="128" height="115"/>
         <image name="person.fill" catalog="system" width="128" height="120"/>
+        <namedColor name="searchBarBorderGray">
+            <color red="0.8784313725490196" green="0.8784313725490196" blue="0.8784313725490196" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
     </resources>
 </document>

--- a/iOS/Airbnb/Airbnb/Base.lproj/Main.storyboard
+++ b/iOS/Airbnb/Airbnb/Base.lproj/Main.storyboard
@@ -102,13 +102,13 @@
                                 </subviews>
                             </stackView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="날짜와 인원을 선택하시면 가격별 숙소를 추천해드립니다." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3YV-Ra-IIz">
-                                <rect key="frame" x="24" y="162" width="327" height="15.666666666666657"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                                <rect key="frame" x="30.666666666666657" y="162" width="313.66666666666674" height="17"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <color key="textColor" name="textGray"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="cNL-Dt-uNR">
-                                <rect key="frame" x="24" y="205.66666666666669" width="327" height="523.33333333333326"/>
+                                <rect key="frame" x="24" y="207" width="327" height="522"/>
                                 <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="frZ-Yj-eii">
                                     <size key="itemSize" width="128" height="128"/>
@@ -133,11 +133,10 @@
                             <constraint firstItem="fB2-6l-Zaj" firstAttribute="top" secondItem="7ak-5z-ugy" secondAttribute="bottom" constant="14" id="Bx4-Mc-xUJ"/>
                             <constraint firstItem="cNL-Dt-uNR" firstAttribute="trailing" secondItem="7ak-5z-ugy" secondAttribute="trailing" id="FKZ-wm-eNn"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="cNL-Dt-uNR" secondAttribute="bottom" id="OcK-8o-Atg"/>
-                            <constraint firstItem="7ak-5z-ugy" firstAttribute="leading" secondItem="3YV-Ra-IIz" secondAttribute="leading" id="P08-MX-11S"/>
                             <constraint firstItem="3YV-Ra-IIz" firstAttribute="top" secondItem="fB2-6l-Zaj" secondAttribute="bottom" constant="14" id="SPo-Xm-9gS"/>
+                            <constraint firstItem="3YV-Ra-IIz" firstAttribute="centerX" secondItem="6Tk-OE-BBY" secondAttribute="centerX" id="bbe-aF-gkR"/>
                             <constraint firstItem="cNL-Dt-uNR" firstAttribute="top" secondItem="3YV-Ra-IIz" secondAttribute="bottom" constant="28" id="dYE-rX-GiS"/>
                             <constraint firstItem="cNL-Dt-uNR" firstAttribute="leading" secondItem="7ak-5z-ugy" secondAttribute="leading" id="jwK-u7-k1i"/>
-                            <constraint firstItem="3YV-Ra-IIz" firstAttribute="trailing" secondItem="7ak-5z-ugy" secondAttribute="trailing" id="kqO-I1-pXY"/>
                             <constraint firstItem="7ak-5z-ugy" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="8" id="lcq-MH-T72"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="7ak-5z-ugy" secondAttribute="trailing" constant="24" id="qt7-zg-dbA"/>
                             <constraint firstItem="fB2-6l-Zaj" firstAttribute="leading" secondItem="7ak-5z-ugy" secondAttribute="leading" id="uWF-vS-7bX"/>

--- a/iOS/Airbnb/Airbnb/Base.lproj/Main.storyboard
+++ b/iOS/Airbnb/Airbnb/Base.lproj/Main.storyboard
@@ -32,11 +32,81 @@
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
                             </textField>
+                            <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="fB2-6l-Zaj">
+                                <rect key="frame" x="24" y="113" width="214" height="38"/>
+                                <subviews>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="giF-a2-P29" customClass="DateButton" customModule="Airbnb" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="0.0" width="66" height="38"/>
+                                        <state key="normal" title="날짜"/>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="horizontalInset">
+                                                <real key="value" value="20"/>
+                                            </userDefinedRuntimeAttribute>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="verticalInset">
+                                                <real key="value" value="10"/>
+                                            </userDefinedRuntimeAttribute>
+                                            <userDefinedRuntimeAttribute type="color" keyPath="color">
+                                                <color key="value" name="textGray"/>
+                                            </userDefinedRuntimeAttribute>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
+                                                <real key="value" value="1"/>
+                                            </userDefinedRuntimeAttribute>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                                <real key="value" value="19"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5pa-D1-Ja1" customClass="GuestsButton" customModule="Airbnb" customModuleProvider="target">
+                                        <rect key="frame" x="74" y="0.0" width="66" height="38"/>
+                                        <state key="normal" title="인원"/>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="horizontalInset">
+                                                <real key="value" value="20"/>
+                                            </userDefinedRuntimeAttribute>
+                                            <userDefinedRuntimeAttribute type="color" keyPath="color">
+                                                <color key="value" name="textGray"/>
+                                            </userDefinedRuntimeAttribute>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="verticalInset">
+                                                <real key="value" value="10"/>
+                                            </userDefinedRuntimeAttribute>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
+                                                <real key="value" value="1"/>
+                                            </userDefinedRuntimeAttribute>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                                <real key="value" value="19"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="glN-kW-FnV" customClass="PriceButton" customModule="Airbnb" customModuleProvider="target">
+                                        <rect key="frame" x="148" y="0.0" width="66" height="38"/>
+                                        <state key="normal" title="가격"/>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="horizontalInset">
+                                                <real key="value" value="20"/>
+                                            </userDefinedRuntimeAttribute>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="verticalInset">
+                                                <real key="value" value="10"/>
+                                            </userDefinedRuntimeAttribute>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
+                                                <real key="value" value="1"/>
+                                            </userDefinedRuntimeAttribute>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                                <real key="value" value="19"/>
+                                            </userDefinedRuntimeAttribute>
+                                            <userDefinedRuntimeAttribute type="color" keyPath="color">
+                                                <color key="value" name="textGray"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                    </button>
+                                </subviews>
+                            </stackView>
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <constraints>
+                            <constraint firstItem="fB2-6l-Zaj" firstAttribute="top" secondItem="7ak-5z-ugy" secondAttribute="bottom" constant="17" id="Bx4-Mc-xUJ"/>
                             <constraint firstItem="7ak-5z-ugy" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="8" id="lcq-MH-T72"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="7ak-5z-ugy" secondAttribute="trailing" constant="24" id="qt7-zg-dbA"/>
+                            <constraint firstItem="fB2-6l-Zaj" firstAttribute="leading" secondItem="7ak-5z-ugy" secondAttribute="leading" id="uWF-vS-7bX"/>
                             <constraint firstItem="7ak-5z-ugy" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="24" id="xpd-xn-bP2"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
@@ -107,6 +177,9 @@
         <image name="person.fill" catalog="system" width="128" height="120"/>
         <namedColor name="searchBarBorderGray">
             <color red="0.8784313725490196" green="0.8784313725490196" blue="0.8784313725490196" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="textGray">
+            <color red="0.4392156862745098" green="0.4392156862745098" blue="0.4392156862745098" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
     </resources>
 </document>

--- a/iOS/Airbnb/Airbnb/Views/FilterButtons/FilterButton.swift
+++ b/iOS/Airbnb/Airbnb/Views/FilterButtons/FilterButton.swift
@@ -61,5 +61,3 @@ class FilterButton: UIButton {
     
     @objc func invokeAction(sender: FilterButton) { }
 }
-
-

--- a/iOS/Airbnb/Airbnb/Views/SearchTextField.swift
+++ b/iOS/Airbnb/Airbnb/Views/SearchTextField.swift
@@ -10,6 +10,14 @@ import UIKit
 
 @IBDesignable
 final class SearchTextField: UITextField {
+    @IBInspectable var color: UIColor = .black {
+        didSet { layer.borderColor = color.cgColor }
+    }
+    
+    @IBInspectable var borderWidth: CGFloat = 1 {
+        didSet { layer.borderWidth = borderWidth }
+    }
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         configureLayer()
@@ -26,9 +34,9 @@ final class SearchTextField: UITextField {
     }
     
     private func configureShadow() {
-        layer.shadowColor = UIColor.black.cgColor
+        layer.shadowColor = UIColor.lightGray.cgColor
         layer.shadowOffset = CGSize(width: 0, height: 0)
-        layer.shadowRadius = 6
+        layer.shadowRadius = 8
         layer.shadowOpacity = 0.2
     }
 }


### PR DESCRIPTION
### 구현한 내용

> Issue #30 의 내용을 구현하였습니다.

* 현재까지 구현된 커스텀 뷰들을 스토리보드에 실제로 올리고, 커스텀 프로퍼티들을 조절하였습니다.
* 오토 레이아웃을 지정하였습니다.
* 막상 스토리보드에 올려보니 텍스트필드의 테두리 색상이 기획서와 다른 것 같아서 테두리 조절 기능을 추가하였습니다.

### 변경된 내용

* 텍스트필드의 그림자를 기획서와 비슷해지도록 약간 조절하였습니다.
* dimGray 컬러셋의 이름과 표현 방식을 변경하였습니다.

### 구현 결과 화면

<p align="center"><img width=300 src="https://user-images.githubusercontent.com/49332230/82734394-b9033e80-9d55-11ea-951b-ef74fb840d76.png"></p>

