### PR TITLE
[iOS] NetworkDispatcher 프로토콜 구현후 Alamofire Session 이 채택하도록 했습니다.  

### DIFF
--- a/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
+++ b/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		5A25EAE4247F84160038240F /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = 5A25EAE3247F84160038240F /* Alamofire */; };
+		5A25EAE6247F84910038240F /* NetworkDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A25EAE5247F84910038240F /* NetworkDispatcher.swift */; };
 		5A33640F2476A39600324367 /* Identifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A33640E2476A39600324367 /* Identifiable.swift */; };
 		5A81411A247BCDE80020ED80 /* BNBsTestData.json in Resources */ = {isa = PBXBuildFile; fileRef = 5A814119247BCDE80020ED80 /* BNBsTestData.json */; };
 		5A81411F247BCE900020ED80 /* BNB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A81411E247BCE900020ED80 /* BNB.swift */; };
@@ -61,6 +62,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		5A25EAE5247F84910038240F /* NetworkDispatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkDispatcher.swift; sourceTree = "<group>"; };
 		5A33640E2476A39600324367 /* Identifiable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Identifiable.swift; sourceTree = "<group>"; };
 		5A814119247BCDE80020ED80 /* BNBsTestData.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = BNBsTestData.json; sourceTree = "<group>"; };
 		5A81411E247BCE900020ED80 /* BNB.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BNB.swift; sourceTree = "<group>"; };
@@ -257,6 +259,7 @@
 				5ADA00DB247E4F3500E30D6C /* EndPoints.swift */,
 				C2205D1E247EAEA9008D3FBC /* Request.swift */,
 				C2205D1F247EAEA9008D3FBC /* BNBRequest.swift */,
+				5A25EAE5247F84910038240F /* NetworkDispatcher.swift */,
 			);
 			path = Networking;
 			sourceTree = "<group>";
@@ -384,6 +387,7 @@
 				C2553CE7247C1CC40019588B /* FilterViewController.swift in Sources */,
 				5A33640F2476A39600324367 /* Identifiable.swift in Sources */,
 				C26F0C8D247640DB002E7F42 /* FilterButton.swift in Sources */,
+				5A25EAE6247F84910038240F /* NetworkDispatcher.swift in Sources */,
 				5A8DB2B424755C30001FC509 /* BadgeLabel.swift in Sources */,
 				C2E54887247D3A47001B400C /* RoundButton.swift in Sources */,
 				C2E54883247C378C001B400C /* CornerRoundedButton.swift in Sources */,

--- a/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
+++ b/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
@@ -3,10 +3,11 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXBuildFile section */
+		5A25EAE4247F84160038240F /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = 5A25EAE3247F84160038240F /* Alamofire */; };
 		5A33640F2476A39600324367 /* Identifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A33640E2476A39600324367 /* Identifiable.swift */; };
 		5A81411A247BCDE80020ED80 /* BNBsTestData.json in Resources */ = {isa = PBXBuildFile; fileRef = 5A814119247BCDE80020ED80 /* BNBsTestData.json */; };
 		5A81411F247BCE900020ED80 /* BNB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A81411E247BCE900020ED80 /* BNB.swift */; };
@@ -111,6 +112,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5A25EAE4247F84160038240F /* Alamofire in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -286,6 +288,9 @@
 			dependencies = (
 			);
 			name = Airbnb;
+			packageProductDependencies = (
+				5A25EAE3247F84160038240F /* Alamofire */,
+			);
 			productName = Airbnb;
 			productReference = C22A52542473A1A80055A478 /* Airbnb.app */;
 			productType = "com.apple.product-type.application";
@@ -336,6 +341,9 @@
 				Base,
 			);
 			mainGroup = C22A524B2473A1A70055A478;
+			packageReferences = (
+				5A25EAE2247F84160038240F /* XCRemoteSwiftPackageReference "Alamofire" */,
+			);
 			productRefGroup = C22A52552473A1A80055A478 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -673,6 +681,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		5A25EAE2247F84160038240F /* XCRemoteSwiftPackageReference "Alamofire" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Alamofire/Alamofire.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.2.1;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		5A25EAE3247F84160038240F /* Alamofire */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 5A25EAE2247F84160038240F /* XCRemoteSwiftPackageReference "Alamofire" */;
+			productName = Alamofire;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = C22A524C2473A1A70055A478 /* Project object */;
 }

--- a/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
+++ b/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		5A25EAE4247F84160038240F /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = 5A25EAE3247F84160038240F /* Alamofire */; };
 		5A25EAE6247F84910038240F /* NetworkDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A25EAE5247F84910038240F /* NetworkDispatcher.swift */; };
+		5A25EAE8247F853B0038240F /* DispatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A25EAE7247F853B0038240F /* DispatcherTests.swift */; };
 		5A33640F2476A39600324367 /* Identifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A33640E2476A39600324367 /* Identifiable.swift */; };
 		5A81411A247BCDE80020ED80 /* BNBsTestData.json in Resources */ = {isa = PBXBuildFile; fileRef = 5A814119247BCDE80020ED80 /* BNBsTestData.json */; };
 		5A81411F247BCE900020ED80 /* BNB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A81411E247BCE900020ED80 /* BNB.swift */; };
@@ -63,6 +64,7 @@
 
 /* Begin PBXFileReference section */
 		5A25EAE5247F84910038240F /* NetworkDispatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkDispatcher.swift; sourceTree = "<group>"; };
+		5A25EAE7247F853B0038240F /* DispatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DispatcherTests.swift; sourceTree = "<group>"; };
 		5A33640E2476A39600324367 /* Identifiable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Identifiable.swift; sourceTree = "<group>"; };
 		5A814119247BCDE80020ED80 /* BNBsTestData.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = BNBsTestData.json; sourceTree = "<group>"; };
 		5A81411E247BCE900020ED80 /* BNB.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BNB.swift; sourceTree = "<group>"; };
@@ -205,6 +207,7 @@
 				C22A52702473A1AB0055A478 /* Info.plist */,
 				5A814121247BD3590020ED80 /* DecodableTests.swift */,
 				5A81412F247BF2BE0020ED80 /* BNBsRequestTests.swift */,
+				5A25EAE7247F853B0038240F /* DispatcherTests.swift */,
 			);
 			path = AirbnbTests;
 			sourceTree = "<group>";
@@ -426,6 +429,7 @@
 			files = (
 				5A814122247BD3590020ED80 /* DecodableTests.swift in Sources */,
 				C22A526F2473A1AB0055A478 /* AirbnbTests.swift in Sources */,
+				5A25EAE8247F853B0038240F /* DispatcherTests.swift in Sources */,
 				5A814130247BF2BE0020ED80 /* BNBsRequestTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/iOS/Airbnb/Airbnb.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/iOS/Airbnb/Airbnb.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "self:Airbnb.xcodeproj">
+      location = "self:">
    </FileRef>
 </Workspace>

--- a/iOS/Airbnb/Airbnb.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iOS/Airbnb/Airbnb.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "Alamofire",
+        "repositoryURL": "https://github.com/Alamofire/Alamofire.git",
+        "state": {
+          "branch": null,
+          "revision": "2777659076fda38bd4e487739ee331c7a65b5924",
+          "version": "5.2.1"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/iOS/Airbnb/Airbnb/Networking/NetworkDispatcher.swift
+++ b/iOS/Airbnb/Airbnb/Networking/NetworkDispatcher.swift
@@ -14,8 +14,6 @@ protocol NetworkDispatcher {
     func excute(request: Request, completionHandler: @escaping (Data?, URLResponse?, Error?) -> ())
 }
 
-extension NetworkDispatcher {}
-
 extension Session: NetworkDispatcher {
     func excute(request: Request, completionHandler: @escaping (Data?, URLResponse?, Error?) -> ()) {
         guard let urlRequest = try? request.urlRequest() else { return }

--- a/iOS/Airbnb/Airbnb/Networking/NetworkDispatcher.swift
+++ b/iOS/Airbnb/Airbnb/Networking/NetworkDispatcher.swift
@@ -1,0 +1,26 @@
+//
+//  NetworkDispatcher.swift
+//  Airbnb
+//
+//  Created by kimdo2297 on 2020/05/28.
+//  Copyright © 2020 Chaewan Park. All rights reserved.
+//
+
+import Foundation
+
+import Alamofire
+
+protocol NetworkDispatcher {
+    func excute(request: Request, completionHandler: @escaping (Data?, URLResponse?, Error?) -> ())
+}
+
+extension NetworkDispatcher {}
+
+extension Session: NetworkDispatcher {
+    func excute(request: Request, completionHandler: @escaping (Data?, URLResponse?, Error?) -> ()) {
+        guard let urlRequest = try? request.urlRequest() else { return }
+        self.request(urlRequest).validate().response { afDataResponse in
+            completionHandler(afDataResponse.data, afDataResponse.response, afDataResponse.error)
+        }
+    }
+}

--- a/iOS/Airbnb/AirbnbTests/DispatcherTests.swift
+++ b/iOS/Airbnb/AirbnbTests/DispatcherTests.swift
@@ -40,7 +40,7 @@ final class DispatcherTests: XCTestCase {
 
             XCTAssertNil(error)
             XCTAssertNotNil(urlResponse)
-            let data = try! XCTUnwrap(Data.readJSON(forResource: "BNBsTestData"))
+            let data = try! XCTUnwrap(data)
             let bnbs = try? JSONDecoder().decode([BNB].self, from: data)
             XCTAssertNotNil(bnbs)
         }

--- a/iOS/Airbnb/AirbnbTests/DispatcherTests.swift
+++ b/iOS/Airbnb/AirbnbTests/DispatcherTests.swift
@@ -1,0 +1,48 @@
+//
+//  DispatcherTests.swift
+//  AirbnbTests
+//
+//  Created by kimdo2297 on 2020/05/28.
+//  Copyright © 2020 Chaewan Park. All rights reserved.
+//
+
+import XCTest
+@testable import Airbnb
+@testable import Alamofire
+
+final class DispatcherTests: XCTestCase {
+    func testAlamofireSession_path_success() {
+        let request = BNBRequest()
+        XCTAssertEqual(request.path, "http://13.125.56.23/api/main")
+    }
+
+    func testAlamofireSession_fetch_success() {
+        let expectation = XCTestExpectation(description: "데이터 잘 들어옴")
+        defer { wait(for: [expectation], timeout: 10.0) }
+
+        let request = BNBRequest()
+        AF.excute(request: request) { data, urlResponse, error in
+            defer { expectation.fulfill() }
+
+            XCTAssertNil(error)
+            XCTAssertNotNil(urlResponse)
+            XCTAssertNotNil(data)
+        }
+    }
+
+    func testAlamofireSession_codable_success() {
+        let expectation = XCTestExpectation(description: "데이터 잘 처리됨")
+        defer { wait(for: [expectation], timeout: 10.0) }
+
+        let request = BNBRequest()
+        AF.excute(request: request) { data, urlResponse, error in
+            defer { expectation.fulfill() }
+
+            XCTAssertNil(error)
+            XCTAssertNotNil(urlResponse)
+            let data = try! XCTUnwrap(Data.readJSON(forResource: "BNBsTestData"))
+            let bnbs = try? JSONDecoder().decode([BNB].self, from: data)
+            XCTAssertNotNil(bnbs)
+        }
+    }
+}


### PR DESCRIPTION
### NetworkDispatcher 프로토콜 구현후 Alamofire Session 이 채택하게 함 

* NetworkDispatcher라는 프로토콜을 만들어 execute 메소드로 request를 보내고 response를 받는 역할을 하도록 구현하였습니다. 
* Alamofire의 Session 객체가 NetworkDispatcher를 채택하여 request를 보내고 response를 받는 역할을 하도록 했습니다. 
* 실제로 Alamofire의 Session 객체가 요청을 잘 보내고 응답을 잘 받는지 test code 를 작성해 확인하였습니다.

