### PR TITLE
[iOS] 받아온 response를 [BNB] 로 처리하는 BNBsTask 객체 구현하였습니다. 

### DIFF
--- a/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
+++ b/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		5A25EAE4247F84160038240F /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = 5A25EAE3247F84160038240F /* Alamofire */; };
 		5A25EAE6247F84910038240F /* NetworkDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A25EAE5247F84910038240F /* NetworkDispatcher.swift */; };
 		5A25EAE8247F853B0038240F /* DispatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A25EAE7247F853B0038240F /* DispatcherTests.swift */; };
+		5A25EAEA247F880D0038240F /* NetworkTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A25EAE9247F880D0038240F /* NetworkTask.swift */; };
+		5A25EAEC247F88330038240F /* BNBsTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A25EAEB247F88330038240F /* BNBsTask.swift */; };
 		5A33640F2476A39600324367 /* Identifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A33640E2476A39600324367 /* Identifiable.swift */; };
 		5A81411A247BCDE80020ED80 /* BNBsTestData.json in Resources */ = {isa = PBXBuildFile; fileRef = 5A814119247BCDE80020ED80 /* BNBsTestData.json */; };
 		5A81411F247BCE900020ED80 /* BNB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A81411E247BCE900020ED80 /* BNB.swift */; };
@@ -65,6 +67,8 @@
 /* Begin PBXFileReference section */
 		5A25EAE5247F84910038240F /* NetworkDispatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkDispatcher.swift; sourceTree = "<group>"; };
 		5A25EAE7247F853B0038240F /* DispatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DispatcherTests.swift; sourceTree = "<group>"; };
+		5A25EAE9247F880D0038240F /* NetworkTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkTask.swift; sourceTree = "<group>"; };
+		5A25EAEB247F88330038240F /* BNBsTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BNBsTask.swift; sourceTree = "<group>"; };
 		5A33640E2476A39600324367 /* Identifiable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Identifiable.swift; sourceTree = "<group>"; };
 		5A814119247BCDE80020ED80 /* BNBsTestData.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = BNBsTestData.json; sourceTree = "<group>"; };
 		5A81411E247BCE900020ED80 /* BNB.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BNB.swift; sourceTree = "<group>"; };
@@ -263,6 +267,8 @@
 				C2205D1E247EAEA9008D3FBC /* Request.swift */,
 				C2205D1F247EAEA9008D3FBC /* BNBRequest.swift */,
 				5A25EAE5247F84910038240F /* NetworkDispatcher.swift */,
+				5A25EAE9247F880D0038240F /* NetworkTask.swift */,
+				5A25EAEB247F88330038240F /* BNBsTask.swift */,
 			);
 			path = Networking;
 			sourceTree = "<group>";
@@ -404,6 +410,8 @@
 				C22A52802473AAB10055A478 /* BookmarkViewController.swift in Sources */,
 				5AD06348247A5BB2000BF31B /* MapButton.swift in Sources */,
 				C2553CE1247C146B0019588B /* NibLoadable.swift in Sources */,
+				5A25EAEA247F880D0038240F /* NetworkTask.swift in Sources */,
+				5A25EAEC247F88330038240F /* BNBsTask.swift in Sources */,
 				C2205D21247EAEA9008D3FBC /* BNBRequest.swift in Sources */,
 				5ADA00DC247E4F3500E30D6C /* EndPoints.swift in Sources */,
 				C22A525C2473A1A80055A478 /* SearchViewController.swift in Sources */,

--- a/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
+++ b/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		5A25EAE8247F853B0038240F /* DispatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A25EAE7247F853B0038240F /* DispatcherTests.swift */; };
 		5A25EAEA247F880D0038240F /* NetworkTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A25EAE9247F880D0038240F /* NetworkTask.swift */; };
 		5A25EAEC247F88330038240F /* BNBsTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A25EAEB247F88330038240F /* BNBsTask.swift */; };
+		5A25EAF0247F88BD0038240F /* BNBsTaskTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A25EAEF247F88BD0038240F /* BNBsTaskTests.swift */; };
 		5A33640F2476A39600324367 /* Identifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A33640E2476A39600324367 /* Identifiable.swift */; };
 		5A81411A247BCDE80020ED80 /* BNBsTestData.json in Resources */ = {isa = PBXBuildFile; fileRef = 5A814119247BCDE80020ED80 /* BNBsTestData.json */; };
 		5A81411F247BCE900020ED80 /* BNB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A81411E247BCE900020ED80 /* BNB.swift */; };
@@ -69,6 +70,7 @@
 		5A25EAE7247F853B0038240F /* DispatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DispatcherTests.swift; sourceTree = "<group>"; };
 		5A25EAE9247F880D0038240F /* NetworkTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkTask.swift; sourceTree = "<group>"; };
 		5A25EAEB247F88330038240F /* BNBsTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BNBsTask.swift; sourceTree = "<group>"; };
+		5A25EAEF247F88BD0038240F /* BNBsTaskTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BNBsTaskTests.swift; sourceTree = "<group>"; };
 		5A33640E2476A39600324367 /* Identifiable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Identifiable.swift; sourceTree = "<group>"; };
 		5A814119247BCDE80020ED80 /* BNBsTestData.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = BNBsTestData.json; sourceTree = "<group>"; };
 		5A81411E247BCE900020ED80 /* BNB.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BNB.swift; sourceTree = "<group>"; };
@@ -212,6 +214,7 @@
 				5A814121247BD3590020ED80 /* DecodableTests.swift */,
 				5A81412F247BF2BE0020ED80 /* BNBsRequestTests.swift */,
 				5A25EAE7247F853B0038240F /* DispatcherTests.swift */,
+				5A25EAEF247F88BD0038240F /* BNBsTaskTests.swift */,
 			);
 			path = AirbnbTests;
 			sourceTree = "<group>";
@@ -438,6 +441,7 @@
 				5A814122247BD3590020ED80 /* DecodableTests.swift in Sources */,
 				C22A526F2473A1AB0055A478 /* AirbnbTests.swift in Sources */,
 				5A25EAE8247F853B0038240F /* DispatcherTests.swift in Sources */,
+				5A25EAF0247F88BD0038240F /* BNBsTaskTests.swift in Sources */,
 				5A814130247BF2BE0020ED80 /* BNBsRequestTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/iOS/Airbnb/Airbnb/Networking/BNBsTask.swift
+++ b/iOS/Airbnb/Airbnb/Networking/BNBsTask.swift
@@ -1,0 +1,28 @@
+//
+//  BNBsTask.swift
+//  Airbnb
+//
+//  Created by kimdo2297 on 2020/05/28.
+//  Copyright © 2020 Chaewan Park. All rights reserved.
+//
+
+import Foundation
+
+final class BNBsTask: NetworkTask {
+    typealias Input = BNBRequest
+    typealias Output = [BNB]
+
+    private let networkDispatcher: NetworkDispatcher
+
+    init(networkDispatcher: NetworkDispatcher) {
+        self.networkDispatcher = networkDispatcher
+    }
+
+    func perform(_ request: BNBRequest, completionHandler: @escaping ([BNB]?) -> ()) {
+        networkDispatcher.excute(request: request) { data, urlResponse, error in
+            guard let data = data else { return }
+            let bnbs = try? JSONDecoder().decode([BNB].self, from: data)
+            completionHandler(bnbs)
+        }
+    }
+}

--- a/iOS/Airbnb/Airbnb/Networking/NetworkTask.swift
+++ b/iOS/Airbnb/Airbnb/Networking/NetworkTask.swift
@@ -1,0 +1,16 @@
+//
+//  NetworkTask.swift
+//  Airbnb
+//
+//  Created by kimdo2297 on 2020/05/28.
+//  Copyright © 2020 Chaewan Park. All rights reserved.
+//
+
+import Foundation
+
+protocol NetworkTask {
+    associatedtype Input: Request
+    associatedtype Output
+
+    func perform(_ request: Input, completionHandler: @escaping (Output?) -> ())
+}

--- a/iOS/Airbnb/AirbnbTests/BNBsTaskTests.swift
+++ b/iOS/Airbnb/AirbnbTests/BNBsTaskTests.swift
@@ -1,0 +1,24 @@
+//
+//  BNBsTaskTests.swift
+//  AirbnbTests
+//
+//  Created by kimdo2297 on 2020/05/28.
+//  Copyright © 2020 Chaewan Park. All rights reserved.
+//
+
+import XCTest
+@testable import Airbnb
+@testable import Alamofire
+
+final class BNBsTaskTests: XCTestCase {
+    func testTaskPerform_success() {
+        let expectation = XCTestExpectation(description: "데이터 잘 처리됨")
+              defer { wait(for: [expectation], timeout: 10.0) }
+        let bnbRequest = BNBRequest()
+        let bnbsTask = BNBsTask(networkDispatcher: AF)
+        bnbsTask.perform(bnbRequest) { bnbs in
+            defer { expectation.fulfill() }
+            _ = try! XCTUnwrap(bnbs)
+        }
+    }
+}


### PR DESCRIPTION
### 받아온 response를 [BNB] 로 처리하는 BNBsTask 객체 구현

* network의 response를 처리하는 객체의 원형인 protocol NetworkTask를 구현하였습니다.
* NetworkTask를 채택한 BNBsTask를 구현하여 받아온 응답을 [BNB]로 처리하도록 하였습니다. 
* BNBsTaskTests 파일을 만들어 BNBsTask가 잘 동작하는지 테스트 하였습니다.
