### PR TITLE
[iOS] BNB 배열([BNB])을 핸들러로 상위객체에게 보낼 BNBsUseCase 를 구현하였습니다.

### DIFF
--- a/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
+++ b/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		5A25EAEC247F88330038240F /* BNBsTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A25EAEB247F88330038240F /* BNBsTask.swift */; };
 		5A25EAF0247F88BD0038240F /* BNBsTaskTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A25EAEF247F88BD0038240F /* BNBsTaskTests.swift */; };
 		5A25EAF2247F8B410038240F /* BNBsUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A25EAF1247F8B410038240F /* BNBsUseCase.swift */; };
+		5A25EAF4247F8F0E0038240F /* BNBsUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A25EAF3247F8F0E0038240F /* BNBsUseCaseTests.swift */; };
 		5A33640F2476A39600324367 /* Identifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A33640E2476A39600324367 /* Identifiable.swift */; };
 		5A81411A247BCDE80020ED80 /* BNBsTestData.json in Resources */ = {isa = PBXBuildFile; fileRef = 5A814119247BCDE80020ED80 /* BNBsTestData.json */; };
 		5A81411F247BCE900020ED80 /* BNB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A81411E247BCE900020ED80 /* BNB.swift */; };
@@ -73,6 +74,7 @@
 		5A25EAEB247F88330038240F /* BNBsTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BNBsTask.swift; sourceTree = "<group>"; };
 		5A25EAEF247F88BD0038240F /* BNBsTaskTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BNBsTaskTests.swift; sourceTree = "<group>"; };
 		5A25EAF1247F8B410038240F /* BNBsUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BNBsUseCase.swift; sourceTree = "<group>"; };
+		5A25EAF3247F8F0E0038240F /* BNBsUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BNBsUseCaseTests.swift; sourceTree = "<group>"; };
 		5A33640E2476A39600324367 /* Identifiable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Identifiable.swift; sourceTree = "<group>"; };
 		5A814119247BCDE80020ED80 /* BNBsTestData.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = BNBsTestData.json; sourceTree = "<group>"; };
 		5A81411E247BCE900020ED80 /* BNB.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BNB.swift; sourceTree = "<group>"; };
@@ -217,6 +219,7 @@
 				5A81412F247BF2BE0020ED80 /* BNBsRequestTests.swift */,
 				5A25EAE7247F853B0038240F /* DispatcherTests.swift */,
 				5A25EAEF247F88BD0038240F /* BNBsTaskTests.swift */,
+				5A25EAF3247F8F0E0038240F /* BNBsUseCaseTests.swift */,
 			);
 			path = AirbnbTests;
 			sourceTree = "<group>";
@@ -444,6 +447,7 @@
 			files = (
 				5A814122247BD3590020ED80 /* DecodableTests.swift in Sources */,
 				C22A526F2473A1AB0055A478 /* AirbnbTests.swift in Sources */,
+				5A25EAF4247F8F0E0038240F /* BNBsUseCaseTests.swift in Sources */,
 				5A25EAE8247F853B0038240F /* DispatcherTests.swift in Sources */,
 				5A25EAF0247F88BD0038240F /* BNBsTaskTests.swift in Sources */,
 				5A814130247BF2BE0020ED80 /* BNBsRequestTests.swift in Sources */,

--- a/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
+++ b/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		5A25EAEA247F880D0038240F /* NetworkTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A25EAE9247F880D0038240F /* NetworkTask.swift */; };
 		5A25EAEC247F88330038240F /* BNBsTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A25EAEB247F88330038240F /* BNBsTask.swift */; };
 		5A25EAF0247F88BD0038240F /* BNBsTaskTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A25EAEF247F88BD0038240F /* BNBsTaskTests.swift */; };
+		5A25EAF2247F8B410038240F /* BNBsUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A25EAF1247F8B410038240F /* BNBsUseCase.swift */; };
 		5A33640F2476A39600324367 /* Identifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A33640E2476A39600324367 /* Identifiable.swift */; };
 		5A81411A247BCDE80020ED80 /* BNBsTestData.json in Resources */ = {isa = PBXBuildFile; fileRef = 5A814119247BCDE80020ED80 /* BNBsTestData.json */; };
 		5A81411F247BCE900020ED80 /* BNB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A81411E247BCE900020ED80 /* BNB.swift */; };
@@ -71,6 +72,7 @@
 		5A25EAE9247F880D0038240F /* NetworkTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkTask.swift; sourceTree = "<group>"; };
 		5A25EAEB247F88330038240F /* BNBsTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BNBsTask.swift; sourceTree = "<group>"; };
 		5A25EAEF247F88BD0038240F /* BNBsTaskTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BNBsTaskTests.swift; sourceTree = "<group>"; };
+		5A25EAF1247F8B410038240F /* BNBsUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BNBsUseCase.swift; sourceTree = "<group>"; };
 		5A33640E2476A39600324367 /* Identifiable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Identifiable.swift; sourceTree = "<group>"; };
 		5A814119247BCDE80020ED80 /* BNBsTestData.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = BNBsTestData.json; sourceTree = "<group>"; };
 		5A81411E247BCE900020ED80 /* BNB.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BNB.swift; sourceTree = "<group>"; };
@@ -247,6 +249,7 @@
 		C22A527B2473A2440055A478 /* UseCases */ = {
 			isa = PBXGroup;
 			children = (
+				5A25EAF1247F8B410038240F /* BNBsUseCase.swift */,
 			);
 			path = UseCases;
 			sourceTree = "<group>";
@@ -414,6 +417,7 @@
 				5AD06348247A5BB2000BF31B /* MapButton.swift in Sources */,
 				C2553CE1247C146B0019588B /* NibLoadable.swift in Sources */,
 				5A25EAEA247F880D0038240F /* NetworkTask.swift in Sources */,
+				5A25EAF2247F8B410038240F /* BNBsUseCase.swift in Sources */,
 				5A25EAEC247F88330038240F /* BNBsTask.swift in Sources */,
 				C2205D21247EAEA9008D3FBC /* BNBRequest.swift in Sources */,
 				5ADA00DC247E4F3500E30D6C /* EndPoints.swift in Sources */,

--- a/iOS/Airbnb/Airbnb/UseCases/BNBsUseCase.swift
+++ b/iOS/Airbnb/Airbnb/UseCases/BNBsUseCase.swift
@@ -8,21 +8,32 @@
 
 import Foundation
 
-struct BNBsUseCase {
+final class  BNBsUseCase {
     private let bnbsTask: BNBsTask
     private var bnbRequests = [BNBRequest]()
+    private var handler: ([BNB]?) -> ()
     
-    init(bnbsTask: BNBsTask) {
+    init(bnbsTask: BNBsTask, handler: @escaping ([BNB]?) -> () = { _ in }) {
         self.bnbsTask = bnbsTask
+        self.handler = handler
     }
     
-    mutating func append(bnbRequest: BNBRequest) {
+    func updateAfter(handler: @escaping ([BNB]?) -> ()) {
+        self.handler = handler
+    }
+    
+    func append(bnbRequest: BNBRequest) {
         bnbRequests.append(bnbRequest)
+        requestBNBs()
     }
     
-    func requestBNBs(completionHandler: @escaping ([BNB]?) -> ()) {
+    private func requestBNBs() {
         guard !bnbRequests.isEmpty else { return }
         guard let bnbRequest = bnbRequests.first else { return }
-        bnbsTask.perform(bnbRequest) { completionHandler($0) }
+        
+        bnbsTask.perform(bnbRequest) { [weak self] bnbs in
+            self!.handler(bnbs)
+        }
     }
 }
+

--- a/iOS/Airbnb/Airbnb/UseCases/BNBsUseCase.swift
+++ b/iOS/Airbnb/Airbnb/UseCases/BNBsUseCase.swift
@@ -18,7 +18,7 @@ final class BNBsUseCase {
         self.handler = handler
     }
     
-    func updateAfter(handler: @escaping ([BNB]?) -> ()) {
+    func updateNotify(handler: @escaping ([BNB]?) -> ()) {
         self.handler = handler
     }
     

--- a/iOS/Airbnb/Airbnb/UseCases/BNBsUseCase.swift
+++ b/iOS/Airbnb/Airbnb/UseCases/BNBsUseCase.swift
@@ -10,8 +10,8 @@ import Foundation
 
 final class  BNBsUseCase {
     private let bnbsTask: BNBsTask
-    private var bnbRequests = [BNBRequest]()
     private var handler: ([BNB]?) -> ()
+    private var bnbRequests = [BNBRequest]() { didSet { requestBNBs() } }
     
     init(bnbsTask: BNBsTask, handler: @escaping ([BNB]?) -> () = { _ in }) {
         self.bnbsTask = bnbsTask
@@ -24,7 +24,6 @@ final class  BNBsUseCase {
     
     func append(bnbRequest: BNBRequest) {
         bnbRequests.append(bnbRequest)
-        requestBNBs()
     }
     
     private func requestBNBs() {

--- a/iOS/Airbnb/Airbnb/UseCases/BNBsUseCase.swift
+++ b/iOS/Airbnb/Airbnb/UseCases/BNBsUseCase.swift
@@ -1,0 +1,28 @@
+//
+//  BNBsUseCase.swift
+//  Airbnb
+//
+//  Created by kimdo2297 on 2020/05/28.
+//  Copyright © 2020 Chaewan Park. All rights reserved.
+//
+
+import Foundation
+
+struct BNBsUseCase {
+    private let bnbsTask: BNBsTask
+    private var bnbRequests = [BNBRequest]()
+    
+    init(bnbsTask: BNBsTask) {
+        self.bnbsTask = bnbsTask
+    }
+    
+    mutating func append(bnbRequest: BNBRequest) {
+        bnbRequests.append(bnbRequest)
+    }
+    
+    func requestBNBs(completionHandler: @escaping ([BNB]?) -> ()) {
+        guard !bnbRequests.isEmpty else { return }
+        guard let bnbRequest = bnbRequests.first else { return }
+        bnbsTask.perform(bnbRequest) { completionHandler($0) }
+    }
+}

--- a/iOS/Airbnb/Airbnb/UseCases/BNBsUseCase.swift
+++ b/iOS/Airbnb/Airbnb/UseCases/BNBsUseCase.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-final class  BNBsUseCase {
+final class BNBsUseCase {
     private let bnbsTask: BNBsTask
     private var handler: ([BNB]?) -> ()
     private var bnbRequests = [BNBRequest]() { didSet { requestBNBs() } }

--- a/iOS/Airbnb/AirbnbTests/BNBsUseCaseTests.swift
+++ b/iOS/Airbnb/AirbnbTests/BNBsUseCaseTests.swift
@@ -29,7 +29,7 @@ final class BNBsUseCaseTests: XCTestCase {
         
         let requestCount = 10
         var count = 0
-        bnbsUseCase.updateAfter { bnbs in
+        bnbsUseCase.updateNotify { bnbs in
             _ = try! XCTUnwrap(bnbs)
             count += 1
             

--- a/iOS/Airbnb/AirbnbTests/BNBsUseCaseTests.swift
+++ b/iOS/Airbnb/AirbnbTests/BNBsUseCaseTests.swift
@@ -1,0 +1,35 @@
+//
+//  BNBsUseCaseTests.swift
+//  AirbnbTests
+//
+//  Created by kimdo2297 on 2020/05/28.
+//  Copyright © 2020 Chaewan Park. All rights reserved.
+//
+
+import XCTest
+@testable import Airbnb
+@testable import Alamofire
+
+final class BNBsUseCaseTests: XCTestCase {
+    let bnbsUseCase = BNBsUseCase(bnbsTask: BNBsTask(networkDispatcher: AF))
+    
+    func testBNBsUseCase_fetch_success() {
+        let expectation = XCTestExpectation(description: "데이터 잘 처리됨")
+        defer { wait(for: [expectation], timeout: 10.0) }
+        
+        let requestCount = 10
+        var count = 0
+        bnbsUseCase.updateAfter { bnbs in
+            _ = try! XCTUnwrap(bnbs)
+            count += 1
+            
+            if count == requestCount {
+                expectation.fulfill()
+            }
+        }
+        
+        for _ in 0 ..< requestCount {
+            bnbsUseCase.append(bnbRequest: BNBRequest())
+        }
+    }
+}

--- a/iOS/Airbnb/AirbnbTests/BNBsUseCaseTests.swift
+++ b/iOS/Airbnb/AirbnbTests/BNBsUseCaseTests.swift
@@ -11,7 +11,17 @@ import XCTest
 @testable import Alamofire
 
 final class BNBsUseCaseTests: XCTestCase {
-    let bnbsUseCase = BNBsUseCase(bnbsTask: BNBsTask(networkDispatcher: AF))
+    var bnbsUseCase: BNBsUseCase!
+    
+    override func setUp() {
+        super.setUp()
+        bnbsUseCase = BNBsUseCase(bnbsTask: BNBsTask(networkDispatcher: AF))
+    }
+    
+    override func tearDown() {
+        bnbsUseCase = nil
+        super.tearDown()
+    }
     
     func testBNBsUseCase_fetch_success() {
         let expectation = XCTestExpectation(description: "데이터 잘 처리됨")


### PR DESCRIPTION
### BNB 배열([BNB])을 핸들러로 상위객체에게 보낼 BNBsUseCase 를 구현

* BNBRequest를 담는 배열을 프로퍼티로 가집니다.
* 메소드 `append(bnbRequest:)`을 통해 외부에서 request를 추가합니다.
* request 배열이 비어있지 않은 경우 bnbsTask 객체를 통해 [BNB]를 fetch 해온후 핸들러를 호출해 [BNB]를 넘깁니다.
* 테스트를 하여 request를 10번 넣었을때 10번 모두 시행되는지 확인하였습니다. 
