### PR TITLE
[iOS] 가격 화면 텍스트 부분 구현 및 PriceViewController 생성하였습니다.

### DIFF
--- a/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
+++ b/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		5A40000124876EBC001F1C63 /* BNBTabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A40000024876EBC001F1C63 /* BNBTabBarController.swift */; };
 		5A40000624879C35001F1C63 /* PriceViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A40000524879C35001F1C63 /* PriceViewController.swift */; };
 		5A40000824879F12001F1C63 /* Price.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 5A40000724879F12001F1C63 /* Price.storyboard */; };
+		5A40000A2488D590001F1C63 /* PriceViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A4000092488D590001F1C63 /* PriceViewModel.swift */; };
 		5A81411F247BCE900020ED80 /* BNB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A81411E247BCE900020ED80 /* BNB.swift */; };
 		5A814124247BD3CD0020ED80 /* DataExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A814123247BD3CD0020ED80 /* DataExtensions.swift */; };
 		5A814130247BF2BE0020ED80 /* SearchRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A81412F247BF2BE0020ED80 /* SearchRequestTests.swift */; };
@@ -98,6 +99,7 @@
 		5A40000024876EBC001F1C63 /* BNBTabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BNBTabBarController.swift; sourceTree = "<group>"; };
 		5A40000524879C35001F1C63 /* PriceViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PriceViewController.swift; sourceTree = "<group>"; };
 		5A40000724879F12001F1C63 /* Price.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Price.storyboard; sourceTree = "<group>"; };
+		5A4000092488D590001F1C63 /* PriceViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PriceViewModel.swift; sourceTree = "<group>"; };
 		5A814119247BCDE80020ED80 /* BNBsTestData.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = BNBsTestData.json; sourceTree = "<group>"; };
 		5A81411E247BCE900020ED80 /* BNB.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BNB.swift; sourceTree = "<group>"; };
 		5A814123247BD3CD0020ED80 /* DataExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataExtensions.swift; sourceTree = "<group>"; };
@@ -283,6 +285,7 @@
 				C2B959C2247E549A003DC5D9 /* BNBViewModels.swift */,
 				5ADA864524838558000C06E9 /* BNBViewModel.swift */,
 				C2587BB2248788FC00CCFE04 /* CalendarViewModel.swift */,
+				5A4000092488D590001F1C63 /* PriceViewModel.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -477,6 +480,7 @@
 				C26F0C8D247640DB002E7F42 /* FilterButton.swift in Sources */,
 				5A25EAE6247F84910038240F /* NetworkDispatcher.swift in Sources */,
 				C2587BB52487899B00CCFE04 /* CalendarCell.swift in Sources */,
+				5A40000A2488D590001F1C63 /* PriceViewModel.swift in Sources */,
 				5A8DB2B424755C30001FC509 /* BadgeLabel.swift in Sources */,
 				C2E54887247D3A47001B400C /* RoundButton.swift in Sources */,
 				C2E54883247C378C001B400C /* CornerRoundedButton.swift in Sources */,

--- a/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
+++ b/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		5A25EAF2247F8B410038240F /* BNBsUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A25EAF1247F8B410038240F /* BNBsUseCase.swift */; };
 		5A33640F2476A39600324367 /* Identifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A33640E2476A39600324367 /* Identifiable.swift */; };
 		5A40000124876EBC001F1C63 /* BNBTabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A40000024876EBC001F1C63 /* BNBTabBarController.swift */; };
+		5A40000624879C35001F1C63 /* PriceViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A40000524879C35001F1C63 /* PriceViewController.swift */; };
+		5A40000824879F12001F1C63 /* Price.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 5A40000724879F12001F1C63 /* Price.storyboard */; };
 		5A81411F247BCE900020ED80 /* BNB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A81411E247BCE900020ED80 /* BNB.swift */; };
 		5A814124247BD3CD0020ED80 /* DataExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A814123247BD3CD0020ED80 /* DataExtensions.swift */; };
 		5A814130247BF2BE0020ED80 /* SearchRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A81412F247BF2BE0020ED80 /* SearchRequestTests.swift */; };
@@ -94,6 +96,8 @@
 		5A25EAF1247F8B410038240F /* BNBsUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BNBsUseCase.swift; sourceTree = "<group>"; };
 		5A33640E2476A39600324367 /* Identifiable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Identifiable.swift; sourceTree = "<group>"; };
 		5A40000024876EBC001F1C63 /* BNBTabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BNBTabBarController.swift; sourceTree = "<group>"; };
+		5A40000524879C35001F1C63 /* PriceViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PriceViewController.swift; sourceTree = "<group>"; };
+		5A40000724879F12001F1C63 /* Price.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Price.storyboard; sourceTree = "<group>"; };
 		5A814119247BCDE80020ED80 /* BNBsTestData.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = BNBsTestData.json; sourceTree = "<group>"; };
 		5A81411E247BCE900020ED80 /* BNB.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BNB.swift; sourceTree = "<group>"; };
 		5A814123247BD3CD0020ED80 /* DataExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataExtensions.swift; sourceTree = "<group>"; };
@@ -234,6 +238,7 @@
 				5ADA864A2483D066000C06E9 /* Login.storyboard */,
 				C2E4EE62247BCDA700671D53 /* Filter.storyboard */,
 				C2587BA82486701800CCFE04 /* Calendar.storyboard */,
+				5A40000724879F12001F1C63 /* Price.storyboard */,
 				C22A52652473A1AB0055A478 /* Info.plist */,
 				C22A52602473A1AB0055A478 /* Assets.xcassets */,
 			);
@@ -301,6 +306,7 @@
 				5ADA864C2483D09E000C06E9 /* LoginViewController.swift */,
 				5A40000024876EBC001F1C63 /* BNBTabBarController.swift */,
 				C2587BAB24867C3700CCFE04 /* CalendarViewController.swift */,
+				5A40000524879C35001F1C63 /* PriceViewController.swift */,
 			);
 			path = Controllers;
 			sourceTree = "<group>";
@@ -444,6 +450,7 @@
 				C22A52612473A1AB0055A478 /* Assets.xcassets in Resources */,
 				C2E4EE63247BCDA700671D53 /* Filter.storyboard in Resources */,
 				C2587BAA2486701800CCFE04 /* Calendar.storyboard in Resources */,
+				5A40000824879F12001F1C63 /* Price.storyboard in Resources */,
 				C22A525F2473A1A80055A478 /* Main.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -506,6 +513,7 @@
 				5ADA864F2483E773000C06E9 /* LoginButton.swift in Sources */,
 				5ADA864D2483D09E000C06E9 /* LoginViewController.swift in Sources */,
 				C22A52582473A1A80055A478 /* AppDelegate.swift in Sources */,
+				5A40000624879C35001F1C63 /* PriceViewController.swift in Sources */,
 				C2B959C3247E549A003DC5D9 /* BNBViewModels.swift in Sources */,
 				C2B959C9247E5C3A003DC5D9 /* NotificationToken.swift in Sources */,
 				C2587BAC24867C3700CCFE04 /* CalendarViewController.swift in Sources */,

--- a/iOS/Airbnb/Airbnb/Base.lproj/Calendar.storyboard
+++ b/iOS/Airbnb/Airbnb/Base.lproj/Calendar.storyboard
@@ -99,7 +99,7 @@
                                         <color key="backgroundColor" red="1" green="0.49327188729999999" blue="0.47399842739999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </collectionViewCell>
                                 </cells>
-                                <collectionReusableView key="sectionHeaderView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="lai-6N-rSd">
+                                <collectionReusableView key="sectionHeaderView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="HeaderTemp" id="lai-6N-rSd">
                                     <rect key="frame" x="0.0" y="0.0" width="360" height="50"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                     <subviews>

--- a/iOS/Airbnb/Airbnb/Base.lproj/Calendar.storyboard
+++ b/iOS/Airbnb/Airbnb/Base.lproj/Calendar.storyboard
@@ -99,7 +99,7 @@
                                         <color key="backgroundColor" red="1" green="0.49327188729999999" blue="0.47399842739999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </collectionViewCell>
                                 </cells>
-                                <collectionReusableView key="sectionHeaderView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="HeaderTemp" id="lai-6N-rSd">
+                                <collectionReusableView key="sectionHeaderView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="lai-6N-rSd">
                                     <rect key="frame" x="0.0" y="0.0" width="360" height="50"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                     <subviews>

--- a/iOS/Airbnb/Airbnb/Controllers/FilterViewController.swift
+++ b/iOS/Airbnb/Airbnb/Controllers/FilterViewController.swift
@@ -30,7 +30,7 @@ final class FilterViewController: UIViewController {
         addChild(priceViewController)
         stackView.insertArrangedSubview(priceViewController.view, at: 1)
         let safeArea = view.safeAreaLayoutGuide
-        priceViewController.view.heightAnchor.constraint(equalTo: safeArea.heightAnchor, multiplier: 0.35).isActive = true
+        priceViewController.view.heightAnchor.constraint(equalTo: safeArea.heightAnchor, multiplier: 0.4).isActive = true
         priceViewController.view.widthAnchor.constraint(equalTo: stackView.widthAnchor).isActive = true
     }
     

--- a/iOS/Airbnb/Airbnb/Controllers/FilterViewController.swift
+++ b/iOS/Airbnb/Airbnb/Controllers/FilterViewController.swift
@@ -18,6 +18,20 @@ final class FilterViewController: UIViewController {
         super.viewDidLoad()
         configureBackgroundDim()
         displaySubViewController()
+        temp_showPriceViewController()
+    }
+    
+    private func temp_showPriceViewController() {
+        guard let priceViewController = PriceViewController.instantiate() else { return }
+        
+        addChild(priceViewController)
+        stackView.insertArrangedSubview(priceViewController.view, at: 1)
+        
+        priceViewController.view.translatesAutoresizingMaskIntoConstraints = false
+        
+        let safeArea = view.safeAreaLayoutGuide
+        priceViewController.view.heightAnchor.constraint(equalTo: safeArea.heightAnchor, multiplier: 0.35).isActive = true
+        priceViewController.view.widthAnchor.constraint(equalTo: stackView.widthAnchor).isActive = true
     }
     
     @IBAction func close(_ sender: UIButton) {

--- a/iOS/Airbnb/Airbnb/Controllers/FilterViewController.swift
+++ b/iOS/Airbnb/Airbnb/Controllers/FilterViewController.swift
@@ -11,27 +11,13 @@ import UIKit
 final class FilterViewController: UIViewController {
     @IBOutlet weak var stackView: UIStackView!
     @IBOutlet weak var filterTitle: UILabel!
-    
 
     private var subViewController: UIViewController?
-    var prices: [(key: Int, value: Int)]?
 
     override func viewDidLoad() {
         super.viewDidLoad()
         configureBackgroundDim()
         displaySubViewController()
-        temp_showPriceViewController()
-    }
-    
-    private func temp_showPriceViewController() {
-        guard let priceViewController = PriceViewController.instantiate() else { return }
-        priceViewController.prices = prices
-        
-        addChild(priceViewController)
-        stackView.insertArrangedSubview(priceViewController.view, at: 1)
-        let safeArea = view.safeAreaLayoutGuide
-        priceViewController.view.heightAnchor.constraint(equalTo: safeArea.heightAnchor, multiplier: 0.4).isActive = true
-        priceViewController.view.widthAnchor.constraint(equalTo: stackView.widthAnchor).isActive = true
     }
     
     @IBAction func close(_ sender: UIButton) {

--- a/iOS/Airbnb/Airbnb/Controllers/FilterViewController.swift
+++ b/iOS/Airbnb/Airbnb/Controllers/FilterViewController.swift
@@ -12,8 +12,10 @@ final class FilterViewController: UIViewController {
     @IBOutlet weak var stackView: UIStackView!
     @IBOutlet weak var filterTitle: UILabel!
     
+
     private var subViewController: UIViewController?
-    
+    var prices: [(key: Int, value: Int)]?
+
     override func viewDidLoad() {
         super.viewDidLoad()
         configureBackgroundDim()
@@ -23,12 +25,10 @@ final class FilterViewController: UIViewController {
     
     private func temp_showPriceViewController() {
         guard let priceViewController = PriceViewController.instantiate() else { return }
+        priceViewController.prices = prices
         
         addChild(priceViewController)
         stackView.insertArrangedSubview(priceViewController.view, at: 1)
-        
-        priceViewController.view.translatesAutoresizingMaskIntoConstraints = false
-        
         let safeArea = view.safeAreaLayoutGuide
         priceViewController.view.heightAnchor.constraint(equalTo: safeArea.heightAnchor, multiplier: 0.35).isActive = true
         priceViewController.view.widthAnchor.constraint(equalTo: stackView.widthAnchor).isActive = true

--- a/iOS/Airbnb/Airbnb/Controllers/PriceViewController.swift
+++ b/iOS/Airbnb/Airbnb/Controllers/PriceViewController.swift
@@ -16,8 +16,13 @@ final class PriceViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        configureTitle()
         configurePriceRange()
         configurePriceAvarage()
+    }
+    
+    private func configureTitle() {
+        title = "가격"
     }
     
     private func configurePriceRange() {

--- a/iOS/Airbnb/Airbnb/Controllers/PriceViewController.swift
+++ b/iOS/Airbnb/Airbnb/Controllers/PriceViewController.swift
@@ -1,0 +1,23 @@
+//
+//  PriceViewController.swift
+//  Airbnb
+//
+//  Created by kimdo2297 on 2020/06/03.
+//  Copyright © 2020 Chaewan Park. All rights reserved.
+//
+
+import UIKit
+
+final class PriceViewController: UIViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+}
+
+extension PriceViewController: Identifiable { }
+
+extension PriceViewController {
+    static func instantiate(from storyboard: StoryboardRouter = .price) -> Self? {
+        return storyboard.load(viewControllerType: self)
+    }
+}

--- a/iOS/Airbnb/Airbnb/Controllers/PriceViewController.swift
+++ b/iOS/Airbnb/Airbnb/Controllers/PriceViewController.swift
@@ -26,12 +26,22 @@ final class PriceViewController: UIViewController {
     }
     
     private func configurePriceRange() {
-        guard let minPrice = prices.first?.key, let maxPrice = prices.last?.key else { return }
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        guard let first = prices.first,
+            let minPrice = formatter.string(from: first.key as NSNumber),
+            let last = prices.last,
+            let maxPrice = formatter.string(from: last.key as NSNumber) else { return }
+        
         priceRange.text = "\(minPrice)원부터 \(maxPrice)원 이상"
     }
     
     private func configurePriceAvarage() {
-        priceAvarage.text = "일박 평균 가격은 \(generateAverage())원"
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        guard let avarage = formatter.string(from: generateAverage() as NSNumber) else { return }
+        
+        priceAvarage.text = "일박 평균 가격은 \(avarage)원"
     }
     
     private func generateAverage() -> Int {

--- a/iOS/Airbnb/Airbnb/Controllers/PriceViewController.swift
+++ b/iOS/Airbnb/Airbnb/Controllers/PriceViewController.swift
@@ -10,16 +10,33 @@ import UIKit
 
 final class PriceViewController: UIViewController {
     @IBOutlet weak var priceRange: UILabel!
+    @IBOutlet weak var priceAvarage: UILabel!
+    
     var prices: [(key: Int, value: Int)]!
     
     override func viewDidLoad() {
         super.viewDidLoad()
         configurePriceRange()
+        configurePriceAvarage()
     }
     
     private func configurePriceRange() {
         guard let minPrice = prices.first?.key, let maxPrice = prices.last?.key else { return }
         priceRange.text = "\(minPrice)원부터 \(maxPrice)원 이상"
+    }
+    
+    private func configurePriceAvarage() {
+        priceAvarage.text = "일박 평균 가격은 \(generateAverage())원"
+    }
+    
+    private func generateAverage() -> Int {
+        var totalPrice = 0
+        var totalCount = 0
+        prices.forEach { price, count in
+            totalPrice += price
+            totalCount += count
+        }
+        return Int(totalPrice / totalCount)
     }
 }
 

--- a/iOS/Airbnb/Airbnb/Controllers/PriceViewController.swift
+++ b/iOS/Airbnb/Airbnb/Controllers/PriceViewController.swift
@@ -9,8 +9,17 @@
 import UIKit
 
 final class PriceViewController: UIViewController {
+    @IBOutlet weak var priceRange: UILabel!
+    var prices: [(key: Int, value: Int)]!
+    
     override func viewDidLoad() {
         super.viewDidLoad()
+        configurePriceRange()
+    }
+    
+    private func configurePriceRange() {
+        guard let minPrice = prices.first?.key, let maxPrice = prices.last?.key else { return }
+        priceRange.text = "\(minPrice)원부터 \(maxPrice)원 이상"
     }
 }
 

--- a/iOS/Airbnb/Airbnb/Controllers/PriceViewController.swift
+++ b/iOS/Airbnb/Airbnb/Controllers/PriceViewController.swift
@@ -12,7 +12,7 @@ final class PriceViewController: UIViewController {
     @IBOutlet weak var priceRange: UILabel!
     @IBOutlet weak var priceAvarage: UILabel!
     
-    var prices: [(key: Int, value: Int)]!
+    var priceViewModel: PriceViewModel?
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -26,32 +26,11 @@ final class PriceViewController: UIViewController {
     }
     
     private func configurePriceRange() {
-        let formatter = NumberFormatter()
-        formatter.numberStyle = .decimal
-        guard let first = prices.first,
-            let minPrice = formatter.string(from: first.key as NSNumber),
-            let last = prices.last,
-            let maxPrice = formatter.string(from: last.key as NSNumber) else { return }
-        
-        priceRange.text = "\(minPrice)원부터 \(maxPrice)원 이상"
+        priceRange.text = priceViewModel?.priceRangeText
     }
     
     private func configurePriceAvarage() {
-        let formatter = NumberFormatter()
-        formatter.numberStyle = .decimal
-        guard let avarage = formatter.string(from: generateAverage() as NSNumber) else { return }
-        
-        priceAvarage.text = "일박 평균 가격은 \(avarage)원"
-    }
-    
-    private func generateAverage() -> Int {
-        var totalPrice = 0
-        var totalCount = 0
-        prices.forEach { price, count in
-            totalPrice += price
-            totalCount += count
-        }
-        return Int(totalPrice / totalCount)
+        priceAvarage.text = priceViewModel?.priceAvarageText
     }
 }
 

--- a/iOS/Airbnb/Airbnb/Controllers/SearchViewController.swift
+++ b/iOS/Airbnb/Airbnb/Controllers/SearchViewController.swift
@@ -61,9 +61,23 @@ final class SearchViewController: UIViewController {
             button.action = { [weak self] viewController in
                 guard let filterViewController = FilterViewController
                     .instantiate(from: .filters, subViewController: viewController) else { return }
+                self?.insertPricesIfPriceType(filterViewController)
                 self?.present(filterViewController, animated: true)
             }
         }
+    }
+    
+    private func insertPricesIfPriceType(_ filterViewController: FilterViewController) {
+        var prices = [Int: Int]()
+        bnbsViewModel.repeatViewModels {
+            let price = $0.bnb.price
+            if let count = prices[$0.bnb.price] {
+                prices.updateValue(count + 1, forKey: price)
+            } else {
+                prices.updateValue(1, forKey: price)
+            }
+        }
+        filterViewController.prices = prices.sorted(by: <)
     }
     
     private func configureUseCase() {

--- a/iOS/Airbnb/Airbnb/Controllers/SearchViewController.swift
+++ b/iOS/Airbnb/Airbnb/Controllers/SearchViewController.swift
@@ -79,7 +79,7 @@ final class SearchViewController: UIViewController {
                 prices.updateValue(1, forKey: price)
             }
         }
-        priceViewController.prices = prices.sorted(by: <)
+        priceViewController.priceViewModel = PriceViewModel(prices: prices.sorted(by: <))
     }
     
     private func configureUseCase() {

--- a/iOS/Airbnb/Airbnb/Controllers/SearchViewController.swift
+++ b/iOS/Airbnb/Airbnb/Controllers/SearchViewController.swift
@@ -61,14 +61,14 @@ final class SearchViewController: UIViewController {
             button.action = { [weak self] viewController in
                 guard let filterViewController = FilterViewController
                     .instantiate(from: .filters, subViewController: viewController) else { return }
-                self?.insertPricesIf(viewController)
+                self?.insertPricesIf(viewController as? PriceViewController)
                 self?.present(filterViewController, animated: true)
             }
         }
     }
     
-    private func insertPricesIf(_ viewController: UIViewController?) {
-        guard let priceViewController = viewController as? PriceViewController else { return }
+    private func insertPricesIf(_ priceViewController: PriceViewController?) {
+        guard let priceViewController = priceViewController else { return }
         
         var prices = [Int: Int]()
         bnbsViewModel.repeatViewModels {

--- a/iOS/Airbnb/Airbnb/Controllers/SearchViewController.swift
+++ b/iOS/Airbnb/Airbnb/Controllers/SearchViewController.swift
@@ -61,13 +61,15 @@ final class SearchViewController: UIViewController {
             button.action = { [weak self] viewController in
                 guard let filterViewController = FilterViewController
                     .instantiate(from: .filters, subViewController: viewController) else { return }
-                self?.insertPricesIfPriceType(filterViewController)
+                self?.insertPricesIf(viewController)
                 self?.present(filterViewController, animated: true)
             }
         }
     }
     
-    private func insertPricesIfPriceType(_ filterViewController: FilterViewController) {
+    private func insertPricesIf(_ viewController: UIViewController?) {
+        guard let priceViewController = viewController as? PriceViewController else { return }
+        
         var prices = [Int: Int]()
         bnbsViewModel.repeatViewModels {
             let price = $0.bnb.price
@@ -77,7 +79,7 @@ final class SearchViewController: UIViewController {
                 prices.updateValue(1, forKey: price)
             }
         }
-        filterViewController.prices = prices.sorted(by: <)
+        priceViewController.prices = prices.sorted(by: <)
     }
     
     private func configureUseCase() {

--- a/iOS/Airbnb/Airbnb/Price.storyboard
+++ b/iOS/Airbnb/Airbnb/Price.storyboard
@@ -14,7 +14,19 @@
                     <view key="view" contentMode="scaleToFill" id="iHs-Ys-SJE">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="313"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="가격 범위" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hyQ-9d-d9d">
+                                <rect key="frame" x="16" y="64" width="74" height="24"/>
+                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="20"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <constraints>
+                            <constraint firstItem="hyQ-9d-d9d" firstAttribute="leading" secondItem="M7Z-Ea-8RG" secondAttribute="leading" constant="16" id="89J-cd-ttR"/>
+                            <constraint firstItem="hyQ-9d-d9d" firstAttribute="top" secondItem="M7Z-Ea-8RG" secondAttribute="top" constant="20" id="9EX-H7-f11"/>
+                        </constraints>
                         <viewLayoutGuide key="safeArea" id="M7Z-Ea-8RG"/>
                     </view>
                     <size key="freeformSize" width="414" height="313"/>

--- a/iOS/Airbnb/Airbnb/Price.storyboard
+++ b/iOS/Airbnb/Airbnb/Price.storyboard
@@ -16,19 +16,19 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="가격 범위" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hyQ-9d-d9d">
-                                <rect key="frame" x="16" y="64" width="74" height="24"/>
+                                <rect key="frame" x="16" y="44" width="74" height="24"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="20"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="가격 범위 레이블" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lUe-Dh-Zkq">
-                                <rect key="frame" x="16" y="118" width="99" height="18"/>
+                                <rect key="frame" x="16" y="88" width="99" height="18"/>
                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="15"/>
                                 <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="가격 평균 레이블" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xar-dI-jOD">
-                                <rect key="frame" x="16" y="143" width="86" height="16"/>
+                                <rect key="frame" x="16" y="113" width="86" height="16"/>
                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="13"/>
                                 <color key="textColor" systemColor="systemGrayColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
@@ -36,12 +36,12 @@
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <constraints>
-                            <constraint firstAttribute="bottom" secondItem="xar-dI-jOD" secondAttribute="bottom" constant="154" id="BNM-m4-rPm"/>
-                            <constraint firstItem="hyQ-9d-d9d" firstAttribute="top" secondItem="iHs-Ys-SJE" secondAttribute="top" constant="64" id="FAx-VX-vAT"/>
-                            <constraint firstItem="hyQ-9d-d9d" firstAttribute="leading" secondItem="iHs-Ys-SJE" secondAttribute="leading" constant="16" id="ObT-B9-zQC"/>
-                            <constraint firstItem="xar-dI-jOD" firstAttribute="leading" secondItem="iHs-Ys-SJE" secondAttribute="leading" constant="16" id="ecV-l1-nvn"/>
-                            <constraint firstItem="lUe-Dh-Zkq" firstAttribute="leading" secondItem="iHs-Ys-SJE" secondAttribute="leading" constant="16" id="qDp-Yc-9qF"/>
-                            <constraint firstItem="lUe-Dh-Zkq" firstAttribute="top" secondItem="hyQ-9d-d9d" secondAttribute="bottom" constant="30" id="s6A-Hr-Tba"/>
+                            <constraint firstItem="hyQ-9d-d9d" firstAttribute="top" secondItem="M7Z-Ea-8RG" secondAttribute="top" id="FAx-VX-vAT"/>
+                            <constraint firstItem="hyQ-9d-d9d" firstAttribute="leading" secondItem="M7Z-Ea-8RG" secondAttribute="leading" constant="16" id="ObT-B9-zQC"/>
+                            <constraint firstItem="M7Z-Ea-8RG" firstAttribute="bottom" secondItem="xar-dI-jOD" secondAttribute="bottom" constant="184" id="aBD-gd-SJU"/>
+                            <constraint firstItem="xar-dI-jOD" firstAttribute="leading" secondItem="M7Z-Ea-8RG" secondAttribute="leading" constant="16" id="ecV-l1-nvn"/>
+                            <constraint firstItem="lUe-Dh-Zkq" firstAttribute="leading" secondItem="M7Z-Ea-8RG" secondAttribute="leading" constant="16" id="qDp-Yc-9qF"/>
+                            <constraint firstItem="lUe-Dh-Zkq" firstAttribute="top" secondItem="hyQ-9d-d9d" secondAttribute="bottom" constant="20" id="s6A-Hr-Tba"/>
                             <constraint firstItem="xar-dI-jOD" firstAttribute="top" secondItem="lUe-Dh-Zkq" secondAttribute="bottom" constant="7" id="xh8-AV-TXz"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="M7Z-Ea-8RG"/>

--- a/iOS/Airbnb/Airbnb/Price.storyboard
+++ b/iOS/Airbnb/Airbnb/Price.storyboard
@@ -36,12 +36,13 @@
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <constraints>
-                            <constraint firstItem="hyQ-9d-d9d" firstAttribute="leading" secondItem="M7Z-Ea-8RG" secondAttribute="leading" constant="16" id="89J-cd-ttR"/>
-                            <constraint firstItem="hyQ-9d-d9d" firstAttribute="top" secondItem="M7Z-Ea-8RG" secondAttribute="top" constant="20" id="9EX-H7-f11"/>
-                            <constraint firstItem="xar-dI-jOD" firstAttribute="leading" secondItem="M7Z-Ea-8RG" secondAttribute="leading" constant="16" id="ecV-l1-nvn"/>
+                            <constraint firstAttribute="bottom" secondItem="xar-dI-jOD" secondAttribute="bottom" constant="154" id="BNM-m4-rPm"/>
+                            <constraint firstItem="hyQ-9d-d9d" firstAttribute="top" secondItem="iHs-Ys-SJE" secondAttribute="top" constant="64" id="FAx-VX-vAT"/>
+                            <constraint firstItem="hyQ-9d-d9d" firstAttribute="leading" secondItem="iHs-Ys-SJE" secondAttribute="leading" constant="16" id="ObT-B9-zQC"/>
+                            <constraint firstItem="xar-dI-jOD" firstAttribute="leading" secondItem="iHs-Ys-SJE" secondAttribute="leading" constant="16" id="ecV-l1-nvn"/>
+                            <constraint firstItem="lUe-Dh-Zkq" firstAttribute="leading" secondItem="iHs-Ys-SJE" secondAttribute="leading" constant="16" id="qDp-Yc-9qF"/>
                             <constraint firstItem="lUe-Dh-Zkq" firstAttribute="top" secondItem="hyQ-9d-d9d" secondAttribute="bottom" constant="30" id="s6A-Hr-Tba"/>
                             <constraint firstItem="xar-dI-jOD" firstAttribute="top" secondItem="lUe-Dh-Zkq" secondAttribute="bottom" constant="7" id="xh8-AV-TXz"/>
-                            <constraint firstItem="lUe-Dh-Zkq" firstAttribute="leading" secondItem="M7Z-Ea-8RG" secondAttribute="leading" constant="16" id="yfn-Ke-OP7"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="M7Z-Ea-8RG"/>
                     </view>

--- a/iOS/Airbnb/Airbnb/Price.storyboard
+++ b/iOS/Airbnb/Airbnb/Price.storyboard
@@ -22,9 +22,15 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="가격 범위 레이블" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lUe-Dh-Zkq">
-                                <rect key="frame" x="16" y="125" width="99" height="18"/>
+                                <rect key="frame" x="16" y="118" width="99" height="18"/>
                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="15"/>
                                 <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="가격 평균 레이블" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xar-dI-jOD">
+                                <rect key="frame" x="16" y="143" width="86" height="16"/>
+                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="13"/>
+                                <color key="textColor" systemColor="systemGrayColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
@@ -32,13 +38,16 @@
                         <constraints>
                             <constraint firstItem="hyQ-9d-d9d" firstAttribute="leading" secondItem="M7Z-Ea-8RG" secondAttribute="leading" constant="16" id="89J-cd-ttR"/>
                             <constraint firstItem="hyQ-9d-d9d" firstAttribute="top" secondItem="M7Z-Ea-8RG" secondAttribute="top" constant="20" id="9EX-H7-f11"/>
-                            <constraint firstItem="lUe-Dh-Zkq" firstAttribute="top" secondItem="hyQ-9d-d9d" secondAttribute="bottom" constant="37" id="s6A-Hr-Tba"/>
+                            <constraint firstItem="xar-dI-jOD" firstAttribute="leading" secondItem="M7Z-Ea-8RG" secondAttribute="leading" constant="16" id="ecV-l1-nvn"/>
+                            <constraint firstItem="lUe-Dh-Zkq" firstAttribute="top" secondItem="hyQ-9d-d9d" secondAttribute="bottom" constant="30" id="s6A-Hr-Tba"/>
+                            <constraint firstItem="xar-dI-jOD" firstAttribute="top" secondItem="lUe-Dh-Zkq" secondAttribute="bottom" constant="7" id="xh8-AV-TXz"/>
                             <constraint firstItem="lUe-Dh-Zkq" firstAttribute="leading" secondItem="M7Z-Ea-8RG" secondAttribute="leading" constant="16" id="yfn-Ke-OP7"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="M7Z-Ea-8RG"/>
                     </view>
                     <size key="freeformSize" width="414" height="313"/>
                     <connections>
+                        <outlet property="priceAvarage" destination="xar-dI-jOD" id="6DR-21-tcn"/>
                         <outlet property="priceRange" destination="lUe-Dh-Zkq" id="fMX-wz-qJK"/>
                     </connections>
                 </viewController>

--- a/iOS/Airbnb/Airbnb/Price.storyboard
+++ b/iOS/Airbnb/Airbnb/Price.storyboard
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Price View Controller-->
+        <scene sceneID="nno-JL-PgH">
+            <objects>
+                <viewController storyboardIdentifier="PriceViewController" id="5VO-OV-f3r" customClass="PriceViewController" customModule="Airbnb" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="iHs-Ys-SJE">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="313"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="M7Z-Ea-8RG"/>
+                    </view>
+                    <size key="freeformSize" width="414" height="313"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="ywK-u4-mkZ" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="268" y="63"/>
+        </scene>
+    </scenes>
+</document>

--- a/iOS/Airbnb/Airbnb/Price.storyboard
+++ b/iOS/Airbnb/Airbnb/Price.storyboard
@@ -17,8 +17,14 @@
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="가격 범위" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hyQ-9d-d9d">
                                 <rect key="frame" x="16" y="64" width="74" height="24"/>
-                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="20"/>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="20"/>
                                 <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="가격 범위 레이블" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lUe-Dh-Zkq">
+                                <rect key="frame" x="16" y="125" width="99" height="18"/>
+                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="15"/>
+                                <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
@@ -26,10 +32,15 @@
                         <constraints>
                             <constraint firstItem="hyQ-9d-d9d" firstAttribute="leading" secondItem="M7Z-Ea-8RG" secondAttribute="leading" constant="16" id="89J-cd-ttR"/>
                             <constraint firstItem="hyQ-9d-d9d" firstAttribute="top" secondItem="M7Z-Ea-8RG" secondAttribute="top" constant="20" id="9EX-H7-f11"/>
+                            <constraint firstItem="lUe-Dh-Zkq" firstAttribute="top" secondItem="hyQ-9d-d9d" secondAttribute="bottom" constant="37" id="s6A-Hr-Tba"/>
+                            <constraint firstItem="lUe-Dh-Zkq" firstAttribute="leading" secondItem="M7Z-Ea-8RG" secondAttribute="leading" constant="16" id="yfn-Ke-OP7"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="M7Z-Ea-8RG"/>
                     </view>
                     <size key="freeformSize" width="414" height="313"/>
+                    <connections>
+                        <outlet property="priceRange" destination="lUe-Dh-Zkq" id="fMX-wz-qJK"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="ywK-u4-mkZ" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>

--- a/iOS/Airbnb/Airbnb/Utils/StoryboardRouter.swift
+++ b/iOS/Airbnb/Airbnb/Utils/StoryboardRouter.swift
@@ -13,6 +13,7 @@ enum StoryboardRouter: String {
     case filters = "Filter"
     case login = "Login"
     case calendar = "Calendar"
+    case price = "Price"
     
     var instance: UIStoryboard {
         return UIStoryboard(name: rawValue, bundle: .main)

--- a/iOS/Airbnb/Airbnb/ViewModels/BNBViewModels.swift
+++ b/iOS/Airbnb/Airbnb/ViewModels/BNBViewModels.swift
@@ -24,6 +24,10 @@ final class BNBViewModels: NSObject {
     func update(bnbs: [BNB]) {
         self.bnbViewModels = bnbs.map { BNBViewModel(bnb: $0) }
     }
+    
+    func repeatViewModels(handler: (BNBViewModel) -> ()) {
+        bnbViewModels.forEach { handler($0) }
+    }
 }
 
 extension BNBViewModels: UICollectionViewDataSource {

--- a/iOS/Airbnb/Airbnb/ViewModels/PriceViewModel.swift
+++ b/iOS/Airbnb/Airbnb/ViewModels/PriceViewModel.swift
@@ -1,0 +1,48 @@
+//
+//  PriceViewModel.swift
+//  Airbnb
+//
+//  Created by kimdo2297 on 2020/06/04.
+//  Copyright © 2020 Chaewan Park. All rights reserved.
+//
+
+import Foundation
+
+final class PriceViewModel {
+    private let prices: [(key: Int, value: Int)]
+    private let formatter: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        return formatter
+    }()
+    
+    init(prices: [(key: Int, value: Int)]) {
+        self.prices = prices
+    }
+    
+    var priceRangeText: String? {
+        guard let first = prices.first, let last = prices.last,
+            let minPrice = formatter.string(from: first.key as NSNumber),
+            let maxPrice = formatter.string(from: last.key as NSNumber) else { return nil }
+        
+        return "\(minPrice)원부터 \(maxPrice)원 이상"
+    }
+    
+    var priceAvarageText: String? {
+        guard let avarage = formatter.string(
+            from: generateAverage() as NSNumber
+            ) else { return nil }
+        
+        return  "일박 평균 가격은 \(avarage)원"
+    }
+    
+    private func generateAverage() -> Int {
+        var totalPrice = 0
+        var totalCount = 0
+        prices.forEach { price, count in
+            totalPrice += price
+            totalCount += count
+        }
+        return Int(totalPrice / totalCount)
+    }
+}

--- a/iOS/Airbnb/Airbnb/Views/FilterButtons/PriceButton.swift
+++ b/iOS/Airbnb/Airbnb/Views/FilterButtons/PriceButton.swift
@@ -11,6 +11,6 @@ import Foundation
 final class PriceButton: FilterButton {
     override func invokeAction(sender: FilterButton) {
         super.invokeAction(sender: sender)
-        action?(nil)
+        action?(PriceViewController.instantiate())
     }
 }


### PR DESCRIPTION
### 가격 화면 텍스트 부분 구현 및 PriceViewController 생성
> Issue #132 을 구현하였습니다.

* 페어의 디자인에 따라 코드를 작성하였습니다.
* `가격` 버튼을 누르면 SearchViewController의 뷰모델에서 가격만 빼와 PriceViewController에 주입하도록 하였습니다. 
* PriceViewModel를 만들어 가격 화면의 텍스트(가격 범위 및 평균)를 만들도록 하였습니다.

<img width="400" alt="price화면" src="https://user-images.githubusercontent.com/38216027/83727436-06e64380-a680-11ea-9fa3-f41c2c0796b7.png">
