### PR TITLE
[BE] token 정보 기반으로 기존 API 리팩토링

### DIFF
--- a/BE/src/main/java/dev/codesquad/airbnb02/application/controller/UserController.java
+++ b/BE/src/main/java/dev/codesquad/airbnb02/application/controller/UserController.java
@@ -1,5 +1,6 @@
 package dev.codesquad.airbnb02.application.controller;
 
+import dev.codesquad.airbnb02.common.jwt.JwtService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -17,6 +18,7 @@ import lombok.RequiredArgsConstructor;
 public class UserController {
 
   private final UserService userService;
+  private final JwtService jwtService;
 
   @GetMapping("/{userId}/favorite/add")
   public ResponseEntity<RoomResponseDto> addFavorite(@PathVariable Long userId,
@@ -30,8 +32,9 @@ public class UserController {
     return ResponseEntity.ok(userService.removeBookmark(userId, roomId));
   }
 
-  @GetMapping("/{userId}/favorite/all")
-  public ResponseEntity viewBookmarkedRooms(@PathVariable Long userId) {
+  @GetMapping("/favorite/all")
+  public ResponseEntity viewBookmarkedRooms() {
+    Long userId = userService.findUserIdByToken();
     return ResponseEntity.ok(userService.getBookmarkedRooms(userId));
   }
 }

--- a/BE/src/main/java/dev/codesquad/airbnb02/application/controller/UserController.java
+++ b/BE/src/main/java/dev/codesquad/airbnb02/application/controller/UserController.java
@@ -1,9 +1,9 @@
 package dev.codesquad.airbnb02.application.controller;
 
-import dev.codesquad.airbnb02.common.jwt.JwtService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -18,17 +18,16 @@ import lombok.RequiredArgsConstructor;
 public class UserController {
 
   private final UserService userService;
-  private final JwtService jwtService;
 
-  @GetMapping("/{userId}/favorite/add")
-  public ResponseEntity<RoomResponseDto> addFavorite(@PathVariable Long userId,
-      @RequestParam(value = "room_id") Long roomId) {
+  @PostMapping("/favorite/add")
+  public ResponseEntity<RoomResponseDto> addFavorite(@RequestParam(value = "room_id") Long roomId) {
+    Long userId = userService.findUserIdByToken();
     return ResponseEntity.ok(userService.addBookmark(userId, roomId));
   }
 
-  @GetMapping("/{userId}/favorite/delete")
-  public ResponseEntity<RoomResponseDto> deleteFavorite(@PathVariable Long userId,
-      @RequestParam(value = "room_id") Long roomId) {
+  @DeleteMapping("/favorite/delete")
+  public ResponseEntity<RoomResponseDto> deleteFavorite(@RequestParam(value = "room_id") Long roomId) {
+    Long userId = userService.findUserIdByToken();
     return ResponseEntity.ok(userService.removeBookmark(userId, roomId));
   }
 

--- a/BE/src/main/java/dev/codesquad/airbnb02/application/dto/RoomDetailResponseDto.java
+++ b/BE/src/main/java/dev/codesquad/airbnb02/application/dto/RoomDetailResponseDto.java
@@ -3,7 +3,7 @@ package dev.codesquad.airbnb02.application.dto;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import dev.codesquad.airbnb02.domain.room.entity.Image;
+import dev.codesquad.airbnb02.domain.room.vo.Image;
 import dev.codesquad.airbnb02.domain.room.entity.Room;
 import dev.codesquad.airbnb02.domain.room.vo.Locale;
 import lombok.Builder;

--- a/BE/src/main/java/dev/codesquad/airbnb02/application/dto/RoomResponseDto.java
+++ b/BE/src/main/java/dev/codesquad/airbnb02/application/dto/RoomResponseDto.java
@@ -3,7 +3,7 @@ package dev.codesquad.airbnb02.application.dto;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import dev.codesquad.airbnb02.domain.room.entity.Image;
+import dev.codesquad.airbnb02.domain.room.vo.Image;
 import dev.codesquad.airbnb02.domain.room.entity.Room;
 import lombok.Builder;
 import lombok.Getter;

--- a/BE/src/main/java/dev/codesquad/airbnb02/common/jwt/JwtInterceptor.java
+++ b/BE/src/main/java/dev/codesquad/airbnb02/common/jwt/JwtInterceptor.java
@@ -24,10 +24,9 @@ public class JwtInterceptor extends HandlerInterceptorAdapter {
     final String token = request.getHeader(AUTHORIZATION);
     log.info("token >> {}", token);
 
-    // 개발 단계에서 원활한 테스트를 위해 인터셉터 주석 처리
-//    if (!jwtService.isValidToken(token)) {
-//      return false;
-//    }
+    if (!jwtService.isValidToken(token)) {
+      return false;
+    }
     return true;
   }
 }

--- a/BE/src/main/java/dev/codesquad/airbnb02/common/jwt/JwtService.java
+++ b/BE/src/main/java/dev/codesquad/airbnb02/common/jwt/JwtService.java
@@ -18,7 +18,7 @@ public class JwtService {
 
   private final String SECRET_KEY = "JinIsTheBest";
   private final String AUTHORIZATION = "Authorization";
-  private final String NULL_TOKEN_USER = "null_token_user";
+  private final String NULL_TOKEN = "Token 정보가 올바르지 않습니다.";
 
   public String createJwt(String userId) {
     final SignatureAlgorithm SIGNATUREALGORITHM = SignatureAlgorithm.HS256;
@@ -60,6 +60,6 @@ public class JwtService {
       Jws<Claims> claims = Jwts.parser().setSigningKey(SECRET_KEY).parseClaimsJws(token);
       return claims.getBody().getSubject();
     }
-    return NULL_TOKEN_USER;
+    throw new InvalidTokenException(NULL_TOKEN);
   }
 }

--- a/BE/src/main/java/dev/codesquad/airbnb02/domain/room/business/RoomService.java
+++ b/BE/src/main/java/dev/codesquad/airbnb02/domain/room/business/RoomService.java
@@ -6,6 +6,7 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,19 +21,15 @@ import lombok.extern.slf4j.Slf4j;
 
 @Service
 @Slf4j
+@RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class RoomService {
 
 	private final RoomRepository roomRepository;
 	private final UserService userService;
 
-	public RoomService(RoomRepository roomRepository, UserService userService) {
-		this.roomRepository = roomRepository;
-		this.userService = userService;
-	}
-
 	public List<RoomResponseDto> findAll() {
-		Long userId = 1L;
+		Long userId = userService.findUserIdByToken();
 		return roomRepository.findAll().stream()
 			.map(room -> RoomResponseDto.create(room, isUserBookmarkedRoom(room.getId(), userId)))
 			.collect(Collectors.toList());
@@ -40,8 +37,7 @@ public class RoomService {
 
 	public List<RoomResponseDto> findFilteredBy(String location, Integer priceMin, Integer priceMax,
 		LocalDate checkin, LocalDate checkout) {
-
-		Long userId = 1L;
+		Long userId = userService.findUserIdByToken();
 		return roomRepository.findAll().stream()
 			.filter(room -> room.isValidLocation(location))
 			.filter(room -> room.isValidPrice(priceMin, priceMax))
@@ -52,7 +48,7 @@ public class RoomService {
 
 	public RoomDetailResponseDto findDetailByRoomId(Long roomId) {
 		Room room = findRoom(roomId);
-		Long userId = 1L;
+		Long userId = userService.findUserIdByToken();
 		boolean favorite = isUserBookmarkedRoom(roomId, userId);
 		return RoomDetailResponseDto.create(room, favorite);
 	}
@@ -64,7 +60,7 @@ public class RoomService {
 
 	@Transactional
 	public BookingResponseDto createBooking(Long roomId, LocalDate checkin, LocalDate checkout) {
-		Long userId = 2L;
+		Long userId = userService.findUserIdByToken();
 		User user = userService.findUser(userId);
 		Room room = findRoom(roomId);
 		if (!room.isValidDate(checkin, checkout)) {
@@ -77,7 +73,7 @@ public class RoomService {
 
 	@Transactional
 	public BookingResponseDto removeBooking(Long roomId, LocalDate checkin, LocalDate checkout) {
-		Long userId = 2L;
+		Long userId = userService.findUserIdByToken();
 		User user = userService.findUser(userId);
 		Room room = findRoom(roomId);
 		room.removeBookings(checkin, checkout, user);

--- a/BE/src/main/java/dev/codesquad/airbnb02/domain/room/entity/Room.java
+++ b/BE/src/main/java/dev/codesquad/airbnb02/domain/room/entity/Room.java
@@ -1,6 +1,7 @@
 package dev.codesquad.airbnb02.domain.room.entity;
 
 import dev.codesquad.airbnb02.common.exception.BookingNotAllowedException;
+import dev.codesquad.airbnb02.domain.room.vo.Image;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;

--- a/BE/src/main/java/dev/codesquad/airbnb02/domain/room/vo/Image.java
+++ b/BE/src/main/java/dev/codesquad/airbnb02/domain/room/vo/Image.java
@@ -1,4 +1,4 @@
-package dev.codesquad.airbnb02.domain.room.entity;
+package dev.codesquad.airbnb02.domain.room.vo;
 
 import javax.persistence.Column;
 import javax.persistence.Embeddable;

--- a/BE/src/main/java/dev/codesquad/airbnb02/domain/user/business/UserService.java
+++ b/BE/src/main/java/dev/codesquad/airbnb02/domain/user/business/UserService.java
@@ -1,5 +1,6 @@
 package dev.codesquad.airbnb02.domain.user.business;
 
+import dev.codesquad.airbnb02.common.jwt.JwtService;
 import dev.codesquad.airbnb02.domain.room.business.RoomService;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -21,6 +22,7 @@ public class UserService {
 
 	private final UserRepository userRepository;
 	private final RoomRepository roomRepository;
+	private final JwtService jwtService;
 
 	@Transactional
 	public RoomResponseDto addBookmark(Long userId, Long roomId) {
@@ -60,5 +62,14 @@ public class UserService {
 		return bookmarkedRoom.stream()
 				.map(room -> RoomResponseDto.create(room, true))
 				.collect(Collectors.toList());
+	}
+
+	public User findUserByGithubId(String githubId) {
+		return userRepository.findUserByGithubId(githubId).orElseThrow(() -> new NotFoundDataException("해당 유저를 찾을 수 없습니다."));
+	}
+
+	public Long findUserIdByToken() {
+		String githubId = jwtService.getUserId();
+		return findUserByGithubId(githubId).getId();
 	}
 }

--- a/BE/src/main/java/dev/codesquad/airbnb02/domain/user/data/UserRepository.java
+++ b/BE/src/main/java/dev/codesquad/airbnb02/domain/user/data/UserRepository.java
@@ -1,8 +1,10 @@
 package dev.codesquad.airbnb02.domain.user.data;
 
 import dev.codesquad.airbnb02.domain.user.entity.User;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
+  Optional<User> findUserByGithubId(String githubId);
 }


### PR DESCRIPTION
### 구현한 내용

* 토큰의 github 유저 정보 기반으로 데이터를 조회합니다.
* 즐겨찾기 추가, 취소 및 리스트 api path에서 userId parameter 제거했습니다.
* issued at #135 
