### PR TITLE
[iOS] 달력에 년, 월, 일 데이터 표시

### DIFF
--- a/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
+++ b/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		5ADA864F2483E773000C06E9 /* LoginButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ADA864E2483E773000C06E9 /* LoginButton.swift */; };
 		5ADA86552484F788000C06E9 /* AuthKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ADA86542484F788000C06E9 /* AuthKeys.swift */; };
 		C203465F24892F4700A16C40 /* FilterSubViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C203465E24892F4700A16C40 /* FilterSubViewController.swift */; };
+		C2034661248957AD00A16C40 /* CalendarViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2034660248957AD00A16C40 /* CalendarViewModelTests.swift */; };
 		C20C5B8924879E2800DED737 /* CalendarLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20C5B8824879E2800DED737 /* CalendarLayout.swift */; };
 		C219C665247D72C4006E3388 /* FavoriteButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = C219C664247D72C4006E3388 /* FavoriteButton.swift */; };
 		C21EB27F248556BC00B3658E /* BNBsTestData.json in Resources */ = {isa = PBXBuildFile; fileRef = 5A814119247BCDE80020ED80 /* BNBsTestData.json */; };
@@ -117,6 +118,7 @@
 		5ADA864E2483E773000C06E9 /* LoginButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginButton.swift; sourceTree = "<group>"; };
 		5ADA86542484F788000C06E9 /* AuthKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthKeys.swift; sourceTree = "<group>"; };
 		C203465E24892F4700A16C40 /* FilterSubViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterSubViewController.swift; sourceTree = "<group>"; };
+		C2034660248957AD00A16C40 /* CalendarViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarViewModelTests.swift; sourceTree = "<group>"; };
 		C20C5B8824879E2800DED737 /* CalendarLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarLayout.swift; sourceTree = "<group>"; };
 		C219C664247D72C4006E3388 /* FavoriteButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteButton.swift; sourceTree = "<group>"; };
 		C2205D1E247EAEA9008D3FBC /* Request.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Request.swift; path = Airbnb/Networking/Request.swift; sourceTree = SOURCE_ROOT; };
@@ -249,6 +251,7 @@
 				5A81412F247BF2BE0020ED80 /* SearchRequestTests.swift */,
 				5A25EAE7247F853B0038240F /* AFSessionTests.swift */,
 				5A25EAEF247F88BD0038240F /* SearchTaskTests.swift */,
+				C2034660248957AD00A16C40 /* CalendarViewModelTests.swift */,
 				C22A52702473A1AB0055A478 /* Info.plist */,
 			);
 			path = AirbnbTests;
@@ -527,6 +530,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C2034661248957AD00A16C40 /* CalendarViewModelTests.swift in Sources */,
 				5A25EAE8247F853B0038240F /* AFSessionTests.swift in Sources */,
 				5A25EAF0247F88BD0038240F /* SearchTaskTests.swift in Sources */,
 				5A814130247BF2BE0020ED80 /* SearchRequestTests.swift in Sources */,

--- a/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
+++ b/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		5ADA864D2483D09E000C06E9 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ADA864C2483D09E000C06E9 /* LoginViewController.swift */; };
 		5ADA864F2483E773000C06E9 /* LoginButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ADA864E2483E773000C06E9 /* LoginButton.swift */; };
 		5ADA86552484F788000C06E9 /* AuthKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ADA86542484F788000C06E9 /* AuthKeys.swift */; };
+		C203465F24892F4700A16C40 /* FilterSubViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C203465E24892F4700A16C40 /* FilterSubViewController.swift */; };
 		C20C5B8924879E2800DED737 /* CalendarLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20C5B8824879E2800DED737 /* CalendarLayout.swift */; };
 		C219C665247D72C4006E3388 /* FavoriteButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = C219C664247D72C4006E3388 /* FavoriteButton.swift */; };
 		C21EB27F248556BC00B3658E /* BNBsTestData.json in Resources */ = {isa = PBXBuildFile; fileRef = 5A814119247BCDE80020ED80 /* BNBsTestData.json */; };
@@ -115,6 +116,7 @@
 		5ADA864C2483D09E000C06E9 /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 		5ADA864E2483E773000C06E9 /* LoginButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginButton.swift; sourceTree = "<group>"; };
 		5ADA86542484F788000C06E9 /* AuthKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthKeys.swift; sourceTree = "<group>"; };
+		C203465E24892F4700A16C40 /* FilterSubViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterSubViewController.swift; sourceTree = "<group>"; };
 		C20C5B8824879E2800DED737 /* CalendarLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarLayout.swift; sourceTree = "<group>"; };
 		C219C664247D72C4006E3388 /* FavoriteButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteButton.swift; sourceTree = "<group>"; };
 		C2205D1E247EAEA9008D3FBC /* Request.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Request.swift; path = Airbnb/Networking/Request.swift; sourceTree = SOURCE_ROOT; };
@@ -298,6 +300,7 @@
 				C22A527F2473AAB10055A478 /* BookmarkViewController.swift */,
 				5A88E8F72473C59800DA79F1 /* ReservationViewController.swift */,
 				C2553CE6247C1CC40019588B /* FilterViewController.swift */,
+				C203465E24892F4700A16C40 /* FilterSubViewController.swift */,
 				5ADA864C2483D09E000C06E9 /* LoginViewController.swift */,
 				5A40000024876EBC001F1C63 /* BNBTabBarController.swift */,
 				C2587BAB24867C3700CCFE04 /* CalendarViewController.swift */,
@@ -512,6 +515,7 @@
 				C22A525A2473A1A80055A478 /* SceneDelegate.swift in Sources */,
 				5A89D248247775F10046629B /* UIEdgeInsetsExtension.swift in Sources */,
 				C2DB830E247668A7007034AC /* DateButton.swift in Sources */,
+				C203465F24892F4700A16C40 /* FilterSubViewController.swift in Sources */,
 				5ADA86552484F788000C06E9 /* AuthKeys.swift in Sources */,
 				5A1D486D24864CF9006F129F /* AuthRequest.swift in Sources */,
 				C219C665247D72C4006E3388 /* FavoriteButton.swift in Sources */,

--- a/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
+++ b/iOS/Airbnb/Airbnb.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		5ADA86552484F788000C06E9 /* AuthKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ADA86542484F788000C06E9 /* AuthKeys.swift */; };
 		C203465F24892F4700A16C40 /* FilterSubViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C203465E24892F4700A16C40 /* FilterSubViewController.swift */; };
 		C2034661248957AD00A16C40 /* CalendarViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2034660248957AD00A16C40 /* CalendarViewModelTests.swift */; };
+		C203466324897A3900A16C40 /* CalendarHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C203466224897A3900A16C40 /* CalendarHeaderView.swift */; };
 		C20C5B8924879E2800DED737 /* CalendarLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20C5B8824879E2800DED737 /* CalendarLayout.swift */; };
 		C219C665247D72C4006E3388 /* FavoriteButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = C219C664247D72C4006E3388 /* FavoriteButton.swift */; };
 		C21EB27F248556BC00B3658E /* BNBsTestData.json in Resources */ = {isa = PBXBuildFile; fileRef = 5A814119247BCDE80020ED80 /* BNBsTestData.json */; };
@@ -119,6 +120,7 @@
 		5ADA86542484F788000C06E9 /* AuthKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthKeys.swift; sourceTree = "<group>"; };
 		C203465E24892F4700A16C40 /* FilterSubViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterSubViewController.swift; sourceTree = "<group>"; };
 		C2034660248957AD00A16C40 /* CalendarViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarViewModelTests.swift; sourceTree = "<group>"; };
+		C203466224897A3900A16C40 /* CalendarHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarHeaderView.swift; sourceTree = "<group>"; };
 		C20C5B8824879E2800DED737 /* CalendarLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarLayout.swift; sourceTree = "<group>"; };
 		C219C664247D72C4006E3388 /* FavoriteButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteButton.swift; sourceTree = "<group>"; };
 		C2205D1E247EAEA9008D3FBC /* Request.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Request.swift; path = Airbnb/Networking/Request.swift; sourceTree = SOURCE_ROOT; };
@@ -273,6 +275,7 @@
 				C29787F5247FF3B500EA9D01 /* ReviewCountLabel.swift */,
 				5ADA864E2483E773000C06E9 /* LoginButton.swift */,
 				C2587BB42487899B00CCFE04 /* CalendarCell.swift */,
+				C203466224897A3900A16C40 /* CalendarHeaderView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -514,6 +517,7 @@
 				C22A52582473A1A80055A478 /* AppDelegate.swift in Sources */,
 				C2B959C3247E549A003DC5D9 /* BNBViewModels.swift in Sources */,
 				C2B959C9247E5C3A003DC5D9 /* NotificationToken.swift in Sources */,
+				C203466324897A3900A16C40 /* CalendarHeaderView.swift in Sources */,
 				C2587BAC24867C3700CCFE04 /* CalendarViewController.swift in Sources */,
 				C22A525A2473A1A80055A478 /* SceneDelegate.swift in Sources */,
 				5A89D248247775F10046629B /* UIEdgeInsetsExtension.swift in Sources */,

--- a/iOS/Airbnb/Airbnb/Base.lproj/Calendar.storyboard
+++ b/iOS/Airbnb/Airbnb/Base.lproj/Calendar.storyboard
@@ -96,7 +96,6 @@
                                                 <constraint firstItem="2Ds-DY-aPy" firstAttribute="centerY" secondItem="IWp-zh-6Aq" secondAttribute="centerY" id="fe7-PK-lFb"/>
                                             </constraints>
                                         </collectionViewCellContentView>
-                                        <color key="backgroundColor" red="1" green="0.49327188729999999" blue="0.47399842739999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </collectionViewCell>
                                 </cells>
                                 <collectionReusableView key="sectionHeaderView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="CalendarHeaderView" id="lai-6N-rSd" customClass="CalendarHeaderView" customModule="Airbnb" customModuleProvider="target">
@@ -110,7 +109,6 @@
                                             <nil key="highlightedColor"/>
                                         </label>
                                     </subviews>
-                                    <color key="backgroundColor" red="0.60383173010000002" green="0.75644919020000001" blue="0.4279714053" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                     <constraints>
                                         <constraint firstItem="QyA-i4-MLZ" firstAttribute="centerY" secondItem="lai-6N-rSd" secondAttribute="centerY" id="4ru-Yu-UXQ"/>
                                         <constraint firstAttribute="trailing" secondItem="QyA-i4-MLZ" secondAttribute="trailing" constant="16" id="K8k-SF-jI9"/>

--- a/iOS/Airbnb/Airbnb/Base.lproj/Calendar.storyboard
+++ b/iOS/Airbnb/Airbnb/Base.lproj/Calendar.storyboard
@@ -104,7 +104,7 @@
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Month Year" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QyA-i4-MLZ">
                                             <rect key="frame" x="16" y="16" width="328" height="18"/>
-                                            <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                            <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="15"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>

--- a/iOS/Airbnb/Airbnb/Base.lproj/Calendar.storyboard
+++ b/iOS/Airbnb/Airbnb/Base.lproj/Calendar.storyboard
@@ -84,8 +84,8 @@
                                             <rect key="frame" x="0.0" y="0.0" width="45" height="45"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2Ds-DY-aPy">
-                                                    <rect key="frame" x="18" y="13.5" width="9.5" height="18"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2Ds-DY-aPy">
+                                                    <rect key="frame" x="22.5" y="22.5" width="0.0" height="0.0"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -96,6 +96,9 @@
                                                 <constraint firstItem="2Ds-DY-aPy" firstAttribute="centerY" secondItem="IWp-zh-6Aq" secondAttribute="centerY" id="fe7-PK-lFb"/>
                                             </constraints>
                                         </collectionViewCellContentView>
+                                        <connections>
+                                            <outlet property="dayLabel" destination="2Ds-DY-aPy" id="qA4-QG-eMB"/>
+                                        </connections>
                                     </collectionViewCell>
                                 </cells>
                                 <collectionReusableView key="sectionHeaderView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="CalendarHeaderView" id="lai-6N-rSd" customClass="CalendarHeaderView" customModule="Airbnb" customModuleProvider="target">

--- a/iOS/Airbnb/Airbnb/Base.lproj/Calendar.storyboard
+++ b/iOS/Airbnb/Airbnb/Base.lproj/Calendar.storyboard
@@ -99,7 +99,7 @@
                                         <color key="backgroundColor" red="1" green="0.49327188729999999" blue="0.47399842739999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </collectionViewCell>
                                 </cells>
-                                <collectionReusableView key="sectionHeaderView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="lai-6N-rSd">
+                                <collectionReusableView key="sectionHeaderView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="CalendarHeaderView" id="lai-6N-rSd" customClass="CalendarHeaderView" customModule="Airbnb" customModuleProvider="target">
                                     <rect key="frame" x="0.0" y="0.0" width="360" height="50"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                     <subviews>
@@ -116,6 +116,9 @@
                                         <constraint firstAttribute="trailing" secondItem="QyA-i4-MLZ" secondAttribute="trailing" constant="16" id="K8k-SF-jI9"/>
                                         <constraint firstItem="QyA-i4-MLZ" firstAttribute="leading" secondItem="lai-6N-rSd" secondAttribute="leading" constant="16" id="xyl-hZ-Kny"/>
                                     </constraints>
+                                    <connections>
+                                        <outlet property="headerLabel" destination="QyA-i4-MLZ" id="Nwf-fh-YDP"/>
+                                    </connections>
                                 </collectionReusableView>
                             </collectionView>
                         </subviews>

--- a/iOS/Airbnb/Airbnb/Base.lproj/Calendar.storyboard
+++ b/iOS/Airbnb/Airbnb/Base.lproj/Calendar.storyboard
@@ -64,7 +64,7 @@
                                     </label>
                                 </subviews>
                             </stackView>
-                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" pagingEnabled="YES" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="Zb1-dT-5hh">
+                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="Zb1-dT-5hh">
                                 <rect key="frame" x="0.0" y="34" width="360" height="346"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                 <constraints>

--- a/iOS/Airbnb/Airbnb/Controllers/CalendarViewController.swift
+++ b/iOS/Airbnb/Airbnb/Controllers/CalendarViewController.swift
@@ -8,7 +8,11 @@
 
 import UIKit
 
-final class CalendarViewController: UIViewController {
+protocol CalendarDelegate: FilterSubViewControllerDelegate {
+    func maxPeriod(_ viewController: CalendarViewController) -> DateComponents
+}
+
+final class CalendarViewController: FilterSubViewController {
     @IBOutlet weak var collectionView: UICollectionView!
     
     private var viewModel = CalendarViewModel()
@@ -21,6 +25,8 @@ final class CalendarViewController: UIViewController {
         
         collectionView.dataSource = viewModel
         collectionView.delegate = layoutDelegate
+        
+        guard let _ = delegate as? CalendarDelegate else { return }
     }
 }
 

--- a/iOS/Airbnb/Airbnb/Controllers/CalendarViewController.swift
+++ b/iOS/Airbnb/Airbnb/Controllers/CalendarViewController.swift
@@ -9,24 +9,33 @@
 import UIKit
 
 protocol CalendarDelegate: FilterSubViewControllerDelegate {
-    func maxPeriod(_ viewController: CalendarViewController) -> DateComponents
+    func durationFromToday(_ viewController: CalendarViewController) -> DateComponents
 }
 
 final class CalendarViewController: FilterSubViewController {
     @IBOutlet weak var collectionView: UICollectionView!
     
-    private var viewModel = CalendarViewModel()
     private var layoutDelegate = CalendarLayout()
+    
+    private var viewModel: CalendarViewModel?
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
         title = "체크인 — 체크아웃"
+
+        configureViewModel()
         
         collectionView.dataSource = viewModel
         collectionView.delegate = layoutDelegate
-        
-        guard let _ = delegate as? CalendarDelegate else { return }
+    }
+    
+    private func configureViewModel() {
+        guard let delegate = delegate as? CalendarDelegate else { return }
+        let duration = delegate.durationFromToday(self)
+        let startDate = Date()
+        guard let endDate = Calendar.current.date(byAdding: duration, to: startDate) else { return }
+        viewModel = CalendarViewModel(startDate: startDate, endDate: endDate)
     }
 }
 

--- a/iOS/Airbnb/Airbnb/Controllers/FilterSubViewController.swift
+++ b/iOS/Airbnb/Airbnb/Controllers/FilterSubViewController.swift
@@ -1,0 +1,15 @@
+//
+//  FilterSubViewController.swift
+//  Airbnb
+//
+//  Created by Chaewan Park on 2020/06/04.
+//  Copyright © 2020 Chaewan Park. All rights reserved.
+//
+
+import UIKit
+
+protocol FilterSubViewControllerDelegate: class { }
+
+class FilterSubViewController: UIViewController {
+    weak var delegate: FilterSubViewControllerDelegate?
+}

--- a/iOS/Airbnb/Airbnb/Controllers/FilterViewController.swift
+++ b/iOS/Airbnb/Airbnb/Controllers/FilterViewController.swift
@@ -56,7 +56,7 @@ extension FilterViewController {
 }
 
 extension FilterViewController: CalendarDelegate {
-    func maxPeriod(_ viewController: CalendarViewController) -> DateComponents {
-        return DateComponents()
+    func durationFromToday(_ viewController: CalendarViewController) -> DateComponents {
+        return DateComponents(year: 1)
     }
 }

--- a/iOS/Airbnb/Airbnb/Controllers/FilterViewController.swift
+++ b/iOS/Airbnb/Airbnb/Controllers/FilterViewController.swift
@@ -12,10 +12,13 @@ final class FilterViewController: UIViewController {
     @IBOutlet weak var stackView: UIStackView!
     @IBOutlet weak var filterTitle: UILabel!
     
-    private var subViewController: UIViewController?
+    private var subViewController: FilterSubViewController?
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        subViewController?.delegate = self
+        
         configureBackgroundDim()
         displaySubViewController()
     }
@@ -42,12 +45,18 @@ extension FilterViewController {
         from storyboard: StoryboardRouter = .filters,
         presentationStyle: UIModalPresentationStyle = .overCurrentContext,
         transitionStyle: UIModalTransitionStyle = .crossDissolve,
-        subViewController: UIViewController?
+        subViewController: FilterSubViewController?
     ) -> Self? {
         guard let viewController = storyboard.load(viewControllerType: self) else { return nil }
         viewController.modalPresentationStyle = presentationStyle
         viewController.modalTransitionStyle = transitionStyle
         viewController.subViewController = subViewController
         return viewController
+    }
+}
+
+extension FilterViewController: CalendarDelegate {
+    func maxPeriod(_ viewController: CalendarViewController) -> DateComponents {
+        return DateComponents()
     }
 }

--- a/iOS/Airbnb/Airbnb/Delegates/CalendarLayout.swift
+++ b/iOS/Airbnb/Airbnb/Delegates/CalendarLayout.swift
@@ -9,6 +9,7 @@
 import UIKit
 
 final class CalendarLayout: NSObject {
+    private var sectionInset = UIEdgeInsets(top: 0, left: 0, bottom: 40, right: 0)
     private var cellSize: CGSize?
 }
 
@@ -21,6 +22,13 @@ extension CalendarLayout: UICollectionViewDelegateFlowLayout {
         let size = collectionView.frame.width / 7
         cellSize = CGSize(width: size, height: size)
         return cellSize!
+    }
+    
+    func collectionView(
+        _ collectionView: UICollectionView,
+        layout collectionViewLayout: UICollectionViewLayout,
+        insetForSectionAt section: Int) -> UIEdgeInsets {
+        return sectionInset
     }
 }
 
@@ -35,7 +43,7 @@ extension CalendarLayout: UIScrollViewDelegate {
             let cellHeight = cellSize?.height else { return }
         
         let targetOffset = targetContentOffset.pointee.y
-        let totalHeight = layout.headerReferenceSize.height + cellHeight * 6
+        let totalHeight = layout.headerReferenceSize.height + cellHeight * 6 + sectionInset.bottom
         
         if scrollView.contentOffset.y > targetContentOffset.pointee.y {
             targetContentOffset.pointee.y = totalHeight * floor(targetOffset / totalHeight)

--- a/iOS/Airbnb/Airbnb/Delegates/CalendarLayout.swift
+++ b/iOS/Airbnb/Airbnb/Delegates/CalendarLayout.swift
@@ -8,7 +8,9 @@
 
 import UIKit
 
-final class CalendarLayout: NSObject { }
+final class CalendarLayout: NSObject {
+    private var cellSize: CGSize?
+}
 
 extension CalendarLayout: UICollectionViewDelegateFlowLayout {
     func collectionView(
@@ -17,6 +19,28 @@ extension CalendarLayout: UICollectionViewDelegateFlowLayout {
         sizeForItemAt indexPath: IndexPath
     ) -> CGSize {
         let size = collectionView.frame.width / 7
-        return CGSize(width: size, height: size)
+        cellSize = CGSize(width: size, height: size)
+        return cellSize!
+    }
+}
+
+extension CalendarLayout: UIScrollViewDelegate {
+    func scrollViewWillEndDragging(
+        _ scrollView: UIScrollView,
+        withVelocity velocity: CGPoint,
+        targetContentOffset: UnsafeMutablePointer<CGPoint>) {
+
+        guard let view = scrollView as? UICollectionView,
+            let layout = view.collectionViewLayout as? UICollectionViewFlowLayout,
+            let cellHeight = cellSize?.height else { return }
+        
+        let targetOffset = targetContentOffset.pointee.y
+        let totalHeight = layout.headerReferenceSize.height + cellHeight * 6
+        
+        if scrollView.contentOffset.y > targetContentOffset.pointee.y {
+            targetContentOffset.pointee.y = totalHeight * floor(targetOffset / totalHeight)
+        } else {
+            targetContentOffset.pointee.y = totalHeight * ceil(targetOffset / totalHeight)
+        }
     }
 }

--- a/iOS/Airbnb/Airbnb/Delegates/CalendarLayout.swift
+++ b/iOS/Airbnb/Airbnb/Delegates/CalendarLayout.swift
@@ -11,6 +11,7 @@ import UIKit
 final class CalendarLayout: NSObject {
     private var sectionInset = UIEdgeInsets(top: 0, left: 0, bottom: 40, right: 0)
     private var cellSize: CGSize?
+    private var startOffset: CGFloat?
 }
 
 extension CalendarLayout: UICollectionViewDelegateFlowLayout {
@@ -33,6 +34,10 @@ extension CalendarLayout: UICollectionViewDelegateFlowLayout {
 }
 
 extension CalendarLayout: UIScrollViewDelegate {
+    func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
+        startOffset = scrollView.contentOffset.y
+    }
+    
     func scrollViewWillEndDragging(
         _ scrollView: UIScrollView,
         withVelocity velocity: CGPoint,
@@ -40,15 +45,15 @@ extension CalendarLayout: UIScrollViewDelegate {
 
         guard let view = scrollView as? UICollectionView,
             let layout = view.collectionViewLayout as? UICollectionViewFlowLayout,
-            let cellHeight = cellSize?.height else { return }
+            let cellHeight = cellSize?.height,
+            let startOffset = startOffset else { return }
         
-        let targetOffset = targetContentOffset.pointee.y
         let totalHeight = layout.headerReferenceSize.height + cellHeight * 6 + sectionInset.bottom
         
         if scrollView.contentOffset.y > targetContentOffset.pointee.y {
-            targetContentOffset.pointee.y = totalHeight * floor(targetOffset / totalHeight)
+            targetContentOffset.pointee.y = startOffset - totalHeight
         } else {
-            targetContentOffset.pointee.y = totalHeight * ceil(targetOffset / totalHeight)
+            targetContentOffset.pointee.y = startOffset + totalHeight
         }
     }
 }

--- a/iOS/Airbnb/Airbnb/Networking/EndPoints.swift
+++ b/iOS/Airbnb/Airbnb/Networking/EndPoints.swift
@@ -10,7 +10,7 @@ import Foundation
 
 enum Endpoints {
     static let baseURL = "http://13.125.56.23/api"
-    static let main = "\(baseURL)/main"
+    static let main = "\(baseURL)/all"
     
     static let authURL = "https://github.com/login/oauth/authorize"
 }

--- a/iOS/Airbnb/Airbnb/ViewModels/CalendarViewModel.swift
+++ b/iOS/Airbnb/Airbnb/ViewModels/CalendarViewModel.swift
@@ -68,7 +68,7 @@ extension CalendarViewModel: UICollectionViewDataSource {
         if monthInfoCache[indexPath.section] == nil { cacheMonthInfo(of: indexPath.section) }
         let monthInfo = monthInfoCache[indexPath.section]!
         let day = indexPath.item - monthInfo.startingIndex + 1
-        if day > 0 { cell.dayLabel.text = "\(day)" }
+        if monthInfo.rangeOfDays.contains(day) { cell.dayLabel.text = "\(day)" }
         return cell
     }
     

--- a/iOS/Airbnb/Airbnb/ViewModels/CalendarViewModel.swift
+++ b/iOS/Airbnb/Airbnb/ViewModels/CalendarViewModel.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 final class CalendarViewModel: NSObject {
-    typealias Key = (startDate: Date, endDate: Date)?
+    typealias Key = (startDate: Date, endDate: Date)
     
     private var period: Key
     
@@ -17,11 +17,18 @@ final class CalendarViewModel: NSObject {
         period = (startDate, endDate)
         super.init()
     }
+    
+    func numberOfMonths() -> Int {
+        return Calendar.current.dateComponents(
+            [.month],
+            from: period.startDate,
+            to: period.endDate).month! + 1
+    }
 }
 
 extension CalendarViewModel: UICollectionViewDataSource {
     func numberOfSections(in collectionView: UICollectionView) -> Int {
-        return 12
+        return numberOfMonths()
     }
     
     func collectionView(

--- a/iOS/Airbnb/Airbnb/ViewModels/CalendarViewModel.swift
+++ b/iOS/Airbnb/Airbnb/ViewModels/CalendarViewModel.swift
@@ -11,18 +11,23 @@ import UIKit
 final class CalendarViewModel: NSObject {
     typealias Key = (startDate: Date, endDate: Date)
     
-    private var period: Key
+    private var calendar: Key
     
     init(startDate: Date, endDate: Date) {
-        period = (startDate, endDate)
+        calendar = (startDate, endDate)
         super.init()
     }
     
     func numberOfMonths() -> Int {
         return Calendar.current.dateComponents(
             [.month],
-            from: period.startDate,
-            to: period.endDate).month! + 1
+            from: calendar.startDate,
+            to: calendar.endDate).month! + 1
+    }
+    
+    func date(withMonthOffsetFromToday offset: Int) -> Date {
+        let monthOffset = DateComponents(month: offset)
+        return Calendar.current.date(byAdding: monthOffset, to: calendar.startDate)!
     }
 }
 
@@ -53,13 +58,25 @@ extension CalendarViewModel: UICollectionViewDataSource {
         _ collectionView: UICollectionView,
         viewForSupplementaryElementOfKind kind: String,
         at indexPath: IndexPath) -> UICollectionReusableView {
+        
         guard case UICollectionView.elementKindSectionHeader = kind,
             let view = collectionView.dequeueReusableSupplementaryView(
                 ofKind: kind, withReuseIdentifier:
                 CalendarHeaderView.identifier,
                 for: indexPath
             ) as? CalendarHeaderView else { return UICollectionReusableView() }
-        view.headerLabel.text = "하하호호"
+        
+        let sectionDate = date(withMonthOffsetFromToday: indexPath.section)
+        view.headerLabel.text = Self.yearAndMonthFormatter.string(from: sectionDate)
         return view
     }
+}
+
+extension CalendarViewModel {
+    static let yearAndMonthFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMMM yyyy"
+        formatter.calendar = Calendar.current
+        return formatter
+    }()
 }

--- a/iOS/Airbnb/Airbnb/ViewModels/CalendarViewModel.swift
+++ b/iOS/Airbnb/Airbnb/ViewModels/CalendarViewModel.swift
@@ -39,6 +39,10 @@ final class CalendarViewModel: NSObject {
             rangeOfDays: rangeOfDaysInMonth,
             startingIndex: weekdayOfFirstDay.weekday! - 1)
     }
+    
+    private func cacheMonthInfo(of section: Int) {
+        monthInfoCache[section] = monthInfo(withOffset: section)
+    }
 }
 
 extension CalendarViewModel: UICollectionViewDataSource {
@@ -61,9 +65,7 @@ extension CalendarViewModel: UICollectionViewDataSource {
             withReuseIdentifier: CalendarCell.identifier,
             for: indexPath
         ) as? CalendarCell else { return UICollectionViewCell() }
-        if monthInfoCache[indexPath.section] == nil {
-            monthInfoCache[indexPath.section] = monthInfo(withOffset: indexPath.section)
-        }
+        if monthInfoCache[indexPath.section] == nil { cacheMonthInfo(of: indexPath.section) }
         let monthInfo = monthInfoCache[indexPath.section]!
         let day = indexPath.item - monthInfo.startingIndex + 1
         if day > 0 { cell.dayLabel.text = "\(day)" }
@@ -81,9 +83,7 @@ extension CalendarViewModel: UICollectionViewDataSource {
                 CalendarHeaderView.identifier,
                 for: indexPath
             ) as? CalendarHeaderView else { return UICollectionReusableView() }
-        if monthInfoCache[indexPath.section] == nil {
-            monthInfoCache[indexPath.section] = monthInfo(withOffset: indexPath.section)
-        }
+        if monthInfoCache[indexPath.section] == nil { cacheMonthInfo(of: indexPath.section) }
         let date = monthInfoCache[indexPath.section]!.dateWithOffset
         view.headerLabel.text = Self.yearAndMonthFormatter.string(from: date)
         return view

--- a/iOS/Airbnb/Airbnb/ViewModels/CalendarViewModel.swift
+++ b/iOS/Airbnb/Airbnb/ViewModels/CalendarViewModel.swift
@@ -48,4 +48,18 @@ extension CalendarViewModel: UICollectionViewDataSource {
         ) as? CalendarCell else { return UICollectionViewCell() }
         return cell
     }
+    
+    func collectionView(
+        _ collectionView: UICollectionView,
+        viewForSupplementaryElementOfKind kind: String,
+        at indexPath: IndexPath) -> UICollectionReusableView {
+        guard case UICollectionView.elementKindSectionHeader = kind,
+            let view = collectionView.dequeueReusableSupplementaryView(
+                ofKind: kind, withReuseIdentifier:
+                CalendarHeaderView.identifier,
+                for: indexPath
+            ) as? CalendarHeaderView else { return UICollectionReusableView() }
+        view.headerLabel.text = "하하호호"
+        return view
+    }
 }

--- a/iOS/Airbnb/Airbnb/ViewModels/CalendarViewModel.swift
+++ b/iOS/Airbnb/Airbnb/ViewModels/CalendarViewModel.swift
@@ -8,7 +8,16 @@
 
 import UIKit
 
-final class CalendarViewModel: NSObject { }
+final class CalendarViewModel: NSObject {
+    typealias Key = (startDate: Date, endDate: Date)?
+    
+    private var period: Key
+    
+    init(startDate: Date, endDate: Date) {
+        period = (startDate, endDate)
+        super.init()
+    }
+}
 
 extension CalendarViewModel: UICollectionViewDataSource {
     func numberOfSections(in collectionView: UICollectionView) -> Int {

--- a/iOS/Airbnb/Airbnb/ViewModels/CalendarViewModel.swift
+++ b/iOS/Airbnb/Airbnb/ViewModels/CalendarViewModel.swift
@@ -11,26 +11,34 @@ import UIKit
 final class CalendarViewModel: NSObject {
     typealias Key = (startDate: Date, endDate: Date)
     
-    private var calendar: Key
+    private var duration: Key
     
+    private var calendar = Calendar.current
     private var monthInfoCache = [Int: MonthInfo]()
     
     init(startDate: Date, endDate: Date) {
-        calendar = (startDate, endDate)
+        duration = (startDate, endDate)
         super.init()
     }
     
     func numberOfMonths() -> Int {
         return Calendar.current.dateComponents(
             [.month],
-            from: calendar.startDate,
-            to: calendar.endDate).month! + 1
+            from: duration.startDate,
+            to: duration.endDate).month! + 1
     }
     
     func cacheMonthInfo(of section: Int) {
-        let date = Calendar.current.date(byAdding: .month, value: section, to: calendar.startDate)!
-        let rangeOfDaysInMonth = Calendar.current.range(of: .day, in: .month, for: date)!
-        monthInfoCache[section] = MonthInfo(dateWitOffset: date, rangeOfDays: rangeOfDaysInMonth)
+        let date = calendar.date(byAdding: .month, value: section, to: duration.startDate)!
+        let rangeOfDaysInMonth = calendar.range(of: .day, in: .month, for: date)!
+        var firstDayOfMonth = calendar.dateComponents([.calendar, .year, .month, .day], from: date)
+        firstDayOfMonth.day = 1
+        let weekdayOfFirstDay = calendar.dateComponents([.weekday], from: firstDayOfMonth.date!)
+        
+        monthInfoCache[section] = MonthInfo(
+            dateWitOffset: date,
+            rangeOfDays: rangeOfDaysInMonth,
+            startingIndex: weekdayOfFirstDay.weekday!)
     }
 }
 
@@ -89,6 +97,6 @@ extension CalendarViewModel {
     struct MonthInfo {
         let dateWitOffset: Date
         let rangeOfDays: Range<Int>
-//        let startingIndex: Int
+        let startingIndex: Int
     }
 }

--- a/iOS/Airbnb/Airbnb/ViewModels/CalendarViewModel.swift
+++ b/iOS/Airbnb/Airbnb/ViewModels/CalendarViewModel.swift
@@ -28,15 +28,14 @@ final class CalendarViewModel: NSObject {
             to: duration.endDate).month! + 1
     }
     
-    func cacheMonthInfo(of section: Int) {
-        let date = calendar.date(byAdding: .month, value: section, to: duration.startDate)!
+    func monthInfo(withOffset offset: Int) -> MonthInfo {
+        let date = calendar.date(byAdding: .month, value: offset, to: duration.startDate)!
         let rangeOfDaysInMonth = calendar.range(of: .day, in: .month, for: date)!
         var firstDayOfMonth = calendar.dateComponents([.calendar, .year, .month, .day], from: date)
         firstDayOfMonth.day = 1
         let weekdayOfFirstDay = calendar.dateComponents([.weekday], from: firstDayOfMonth.date!)
-        
-        monthInfoCache[section] = MonthInfo(
-            dateWitOffset: date,
+        return MonthInfo(
+            dateWithOffset: date,
             rangeOfDays: rangeOfDaysInMonth,
             startingIndex: weekdayOfFirstDay.weekday!)
     }
@@ -76,8 +75,8 @@ extension CalendarViewModel: UICollectionViewDataSource {
                 CalendarHeaderView.identifier,
                 for: indexPath
             ) as? CalendarHeaderView else { return UICollectionReusableView() }
-        cacheMonthInfo(of: indexPath.section)
-        if let date = monthInfoCache[indexPath.section]?.dateWitOffset {
+        monthInfoCache[indexPath.section] = monthInfo(withOffset: indexPath.section)
+        if let date = monthInfoCache[indexPath.section]?.dateWithOffset {
             view.headerLabel.text = Self.yearAndMonthFormatter.string(from: date)
         }
         return view
@@ -94,8 +93,8 @@ extension CalendarViewModel {
 }
 
 extension CalendarViewModel {
-    struct MonthInfo {
-        let dateWitOffset: Date
+    struct MonthInfo: Equatable {
+        let dateWithOffset: Date
         let rangeOfDays: Range<Int>
         let startingIndex: Int
     }

--- a/iOS/Airbnb/Airbnb/ViewModels/CalendarViewModel.swift
+++ b/iOS/Airbnb/Airbnb/ViewModels/CalendarViewModel.swift
@@ -37,7 +37,7 @@ final class CalendarViewModel: NSObject {
         return MonthInfo(
             dateWithOffset: date,
             rangeOfDays: rangeOfDaysInMonth,
-            startingIndex: weekdayOfFirstDay.weekday!)
+            startingIndex: weekdayOfFirstDay.weekday! - 1)
     }
 }
 
@@ -61,6 +61,12 @@ extension CalendarViewModel: UICollectionViewDataSource {
             withReuseIdentifier: CalendarCell.identifier,
             for: indexPath
         ) as? CalendarCell else { return UICollectionViewCell() }
+        if monthInfoCache[indexPath.section] == nil {
+            monthInfoCache[indexPath.section] = monthInfo(withOffset: indexPath.section)
+        }
+        let monthInfo = monthInfoCache[indexPath.section]!
+        let day = indexPath.item - monthInfo.startingIndex + 1
+        if day > 0 { cell.dayLabel.text = "\(day)" }
         return cell
     }
     
@@ -75,10 +81,11 @@ extension CalendarViewModel: UICollectionViewDataSource {
                 CalendarHeaderView.identifier,
                 for: indexPath
             ) as? CalendarHeaderView else { return UICollectionReusableView() }
-        monthInfoCache[indexPath.section] = monthInfo(withOffset: indexPath.section)
-        if let date = monthInfoCache[indexPath.section]?.dateWithOffset {
-            view.headerLabel.text = Self.yearAndMonthFormatter.string(from: date)
+        if monthInfoCache[indexPath.section] == nil {
+            monthInfoCache[indexPath.section] = monthInfo(withOffset: indexPath.section)
         }
+        let date = monthInfoCache[indexPath.section]!.dateWithOffset
+        view.headerLabel.text = Self.yearAndMonthFormatter.string(from: date)
         return view
     }
 }

--- a/iOS/Airbnb/Airbnb/Views/CalendarCell.swift
+++ b/iOS/Airbnb/Airbnb/Views/CalendarCell.swift
@@ -9,7 +9,11 @@
 import UIKit
 
 class CalendarCell: UICollectionViewCell {
+    @IBOutlet weak var dayLabel: UILabel!
     
+    override func prepareForReuse() {
+        dayLabel.text = nil
+    }
 }
 
 extension CalendarCell: Identifiable { }

--- a/iOS/Airbnb/Airbnb/Views/CalendarHeaderView.swift
+++ b/iOS/Airbnb/Airbnb/Views/CalendarHeaderView.swift
@@ -1,0 +1,15 @@
+//
+//  CalendarHeaderView.swift
+//  Airbnb
+//
+//  Created by Chaewan Park on 2020/06/05.
+//  Copyright © 2020 Chaewan Park. All rights reserved.
+//
+
+import UIKit
+
+class CalendarHeaderView: UICollectionReusableView {
+    @IBOutlet weak var headerLabel: UILabel!
+}
+
+extension CalendarHeaderView: Identifiable { }

--- a/iOS/Airbnb/Airbnb/Views/FilterButtons/FilterButton.swift
+++ b/iOS/Airbnb/Airbnb/Views/FilterButtons/FilterButton.swift
@@ -30,7 +30,7 @@ class FilterButton: UIButton {
         didSet { layer.cornerRadius = cornerRadius }
     }
     
-    var action: ((UIViewController?) -> Void)?
+    var action: ((FilterSubViewController?) -> Void)?
     
     override init(frame: CGRect) {
         super.init(frame: frame)

--- a/iOS/Airbnb/AirbnbTests/CalendarViewModelTests.swift
+++ b/iOS/Airbnb/AirbnbTests/CalendarViewModelTests.swift
@@ -11,9 +11,29 @@ import XCTest
 
 class CalendarViewModelTests: XCTestCase {
     func testNumberOfMonths_ForTwoYears() {
-        let startDate = Date()
-        let endDate = Calendar.current.date(byAdding: DateComponents(year: 2), to: startDate)!
-        let viewModel = CalendarViewModel(startDate: startDate, endDate: endDate)
+        let viewModel = CalendarViewModel(
+            startDate: DateStubs.startDate,
+            endDate: DateStubs.endDateAfterTwoYears)
         XCTAssertEqual(viewModel.numberOfMonths(), 25)
     }
+    
+    func testYearAndMonth_After3MonthOffset() {
+        let viewModel = CalendarViewModel(
+            startDate: DateStubs.startDate,
+            endDate: DateStubs.endDateAfterOneYear)
+        let date = viewModel.date(withMonthOffsetFromToday: 3)
+        let dateComponents = Calendar.current.dateComponents([.year, .month, .day], from: date)
+        let expectedDateComponents = DateComponents(year: 2020, month: 9, day: 5)
+        XCTAssertEqual(dateComponents, expectedDateComponents)
+    }
+}
+
+struct DateStubs {
+    static let calendar = Calendar.current
+    static let oneYear = DateComponents(year: 1)
+    static let twoYears = DateComponents(year: 2)
+    
+    static let startDate = DateComponents(calendar: .current, year: 2020, month: 6, day: 5).date!
+    static let endDateAfterOneYear = calendar.date(byAdding: oneYear, to: startDate)!
+    static let endDateAfterTwoYears = calendar.date(byAdding: twoYears, to: startDate)!
 }

--- a/iOS/Airbnb/AirbnbTests/CalendarViewModelTests.swift
+++ b/iOS/Airbnb/AirbnbTests/CalendarViewModelTests.swift
@@ -25,7 +25,7 @@ class CalendarViewModelTests: XCTestCase {
         let expectedMonthInfo = CalendarViewModel.MonthInfo(
             dateWithOffset: DateComponents(calendar: .current, year: 2020, month: 8, day: 5).date!,
             rangeOfDays: (1..<32),
-            startingIndex: 7)
+            startingIndex: 6)
         XCTAssertEqual(monthInfo, expectedMonthInfo)
     }
 }

--- a/iOS/Airbnb/AirbnbTests/CalendarViewModelTests.swift
+++ b/iOS/Airbnb/AirbnbTests/CalendarViewModelTests.swift
@@ -1,0 +1,19 @@
+//
+//  CalendarViewModelTests.swift
+//  AirbnbTests
+//
+//  Created by Chaewan Park on 2020/06/05.
+//  Copyright © 2020 Chaewan Park. All rights reserved.
+//
+
+import XCTest
+@testable import Airbnb
+
+class CalendarViewModelTests: XCTestCase {
+    func testNumberOfMonths_ForTwoYears() {
+        let startDate = Date()
+        let endDate = Calendar.current.date(byAdding: DateComponents(year: 2), to: startDate)!
+        let viewModel = CalendarViewModel(startDate: startDate, endDate: endDate)
+        XCTAssertEqual(viewModel.numberOfMonths(), 25)
+    }
+}

--- a/iOS/Airbnb/AirbnbTests/CalendarViewModelTests.swift
+++ b/iOS/Airbnb/AirbnbTests/CalendarViewModelTests.swift
@@ -17,14 +17,16 @@ class CalendarViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.numberOfMonths(), 25)
     }
     
-    func testYearAndMonth_After3MonthOffset() {
+    func testMonthInfo_With2MonthOffset() {
         let viewModel = CalendarViewModel(
             startDate: DateStubs.startDate,
             endDate: DateStubs.endDateAfterOneYear)
-        let date = viewModel.date(withMonthOffsetFromToday: 3)
-        let dateComponents = Calendar.current.dateComponents([.year, .month, .day], from: date)
-        let expectedDateComponents = DateComponents(year: 2020, month: 9, day: 5)
-        XCTAssertEqual(dateComponents, expectedDateComponents)
+        let monthInfo = viewModel.monthInfo(withOffset: 2)
+        let expectedMonthInfo = CalendarViewModel.MonthInfo(
+            dateWithOffset: DateComponents(calendar: .current, year: 2020, month: 8, day: 5).date!,
+            rangeOfDays: (1..<32),
+            startingIndex: 7)
+        XCTAssertEqual(monthInfo, expectedMonthInfo)
     }
 }
 


### PR DESCRIPTION
### 구현한 내용

> Issue #142 를 구현하였습니다.

- 델리게이트를 통해 달력에 표시할 기간을 입력받은 후 해당 기간의 년, 월, 일을 컬렉션뷰 헤더와 셀에 표시하였습니다.
- 년, 월, 일을 표시하는 로직을 캘린더 뷰모델에 구현하였고, 캘린더 뷰모델의 로직을 테스트하기 위한 테스트코드를 작성하였습니다.
- 커스텀 페이징을 구현하였습니다.

### 고민한 내용

- 델리게이트 패턴 이용시에도 Filter VC에서 구체 타입에 의존하지 않도록 하기 위해 Filter Sub VC를 추가하였습니다.
- 기본 스크롤뷰 페이징을 이용할 경우 오차가 누적되어 점점 밀리는 문제가 발생하여 직접 section의 높이를 계산하여 페이징을 구현하였습니다.

### 구현 결과 화면

<p align="center"><img width=300 src="https://user-images.githubusercontent.com/49332230/83894577-70ec0f00-a78c-11ea-8f80-85892b1a6950.png"></p>
